### PR TITLE
fix: Restore interp for all exception clauses

### DIFF
--- a/.github/workflows/runtime-ci.yml
+++ b/.github/workflows/runtime-ci.yml
@@ -77,7 +77,6 @@ jobs:
 
         git apply ..\patches\enable-idbfs.patch
         git apply ..\patches\dbg-proxy-net5.patch
-        git apply ..\patches\bug56309.patch
         git config --global user.email "ci@platform.uno"
         git config --global user.name "Uno Platform CI"
         git add .
@@ -231,7 +230,6 @@ jobs:
 
         git apply ../patches/enable-idbfs.patch
         git apply ../patches/dbg-proxy-net5.patch
-        git apply ../patches/bug56309.patch
         git config --global user.email "ci@platform.uno"
         git config --global user.name "Uno Platform CI"
         git add .


### PR DESCRIPTION
The original patch seems to be causing side effects, reverting.