### PR TITLE
fix: Update to latest runtime

### DIFF
--- a/.github/workflows/runtime-ci.yml
+++ b/.github/workflows/runtime-ci.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   EMSDK_VERSION: 3.1.34 # align with https://github.com/dotnet/runtime/blob/4ae9b33cc5bd291abd18d5b4353adf780f6810bc/src/mono/wasm/emscripten-version.txt
-  DOTNETRUNTIME_COMMIT: 57cfd0624054e7260fae0a4f3d2d6ee4d02995ca
+  DOTNETRUNTIME_COMMIT: 65b696cf5e7599ad68107138a1acb643d1cedd9d
   DOTNETSDK_VERSION: 8.0.100-preview.4.23260.5
   ADDITIONAL_BUILD_ARGS: '/p:MonoEnableAssertMessages=true /p:WasmEnableES6=true /p:WasmExceptionHandling=true'
 


### PR DESCRIPTION
PR https://github.com/dotnet/runtime/pull/87857 breaks us. See https://github.com/unoplatform/uno/pull/13184. This change updates the runtime.