### PR TITLE
chore: Add aot compiler unknown failure workaround

### DIFF
--- a/patches/0016-fix-Avoid-AOT-null-generic-crash.patch
+++ b/patches/0016-fix-Avoid-AOT-null-generic-crash.patch
@@ -1,0 +1,26 @@
+From f229efd4fc15a29d72d8af58fa70d130ff595352 Mon Sep 17 00:00:00 2001
+From: jerome laban <jerome@platform.uno>
+Date: Fri, 28 Jun 2024 21:38:43 +0000
+Subject: [PATCH] fix: Avoid AOT null generic crash
+
+---
+ src/mono/mono/metadata/metadata.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/mono/mono/metadata/metadata.c b/src/mono/mono/metadata/metadata.c
+index f9abe652b01..89cb9a66b6b 100644
+--- a/src/mono/mono/metadata/metadata.c
++++ b/src/mono/mono/metadata/metadata.c
+@@ -5508,6 +5508,9 @@ mono_metadata_generic_class_is_valuetype (MonoGenericClass *gclass)
+ static gboolean
+ _mono_metadata_generic_class_equal (const MonoGenericClass *g1, const MonoGenericClass *g2, gboolean signature_only)
+ {
++	if (!g1 || !g2)
++		return FALSE;
++
+ 	MonoGenericInst *i1 = g1->context.class_inst;
+ 	MonoGenericInst *i2 = g2->context.class_inst;
+ 
+-- 
+2.39.2
+


### PR DESCRIPTION
Fix for segfault:

```
Starting program: /mnt/c/Users/jela/AppData/Local/Temp/dotnet-runtime-wasm-linux-498e18e-7331dcb60e0-8790049905-Release-simd/runtimes/browser-wasm/native/cross/browser-wasm/mono-aot-cross --debug --wasm-exceptions --aot=dedup-skip,llvmonly,asmonly,no-opt,static,direct-icalls,deterministic,nodebug,llvm-path=/home/jay/.uno/emsdk/emsdk-3.1.34/emsdk/upstream/bin,profile=/mnt/d/s/uno.github/uno.gallery/Uno.Gallery/obj/Release/net8.0-browserwasm/aot-filtered.profile,profile-only,interp,mattr=simd,,depfile=./linker-out/Uno.UI.Composition.dll.depfile,llvm-outfile=./Uno.UI.Composition.dll.bc.tmp ./linker-out/Uno.UI.Composition.dll
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Mono Ahead of Time compiler - compiling assembly /mnt/d/s/uno.github/uno.gallery/Uno.Gallery/obj/Release/net8.0-browserwasm/workAot/linker-out/Uno.UI.Composition.dll
Using profile data file '/mnt/d/s/uno.github/uno.gallery/Uno.Gallery/obj/Release/net8.0-browserwasm/aot-filtered.profile'

Program received signal SIGSEGV, Segmentation fault.
0x00005555556b2c97 in _mono_metadata_generic_class_equal (g1=0x0, g2=0x555556d232f0, signature_only=1) at /home/jay/runtime/src/mono/mono/metadata/metadata.c:5511
5511    /home/jay/runtime/src/mono/mono/metadata/metadata.c: No such file or directory.
(gdb) bp
Undefined command: "bp".  Try "help".
(gdb) bt
#0  0x00005555556b2c97 in _mono_metadata_generic_class_equal (g1=0x0, g2=0x555556d232f0, signature_only=1) at /home/jay/runtime/src/mono/mono/metadata/metadata.c:5511
#1  0x00005555556ac2db in do_mono_metadata_type_equal (t1=0x555556d54898, t2=0x555556d55fa0, equiv_flags=3) at /home/jay/runtime/src/mono/mono/metadata/metadata.c:5861
#2  0x00005555556ac574 in signature_equiv (sig1=0x555556d54880, sig2=0x555556d55f90, equiv_flags=2) at /home/jay/runtime/src/mono/mono/metadata/metadata.c:5980
#3  0x00005555556ac5f2 in mono_metadata_signature_equal_ignore_custom_modifier (sig1=0x555556d54880, sig2=0x555556d55f90)
    at /home/jay/runtime/src/mono/mono/metadata/metadata.c:5942
#4  0x0000555555919519 in find_method_simple (klass=0x555556d292f0, name=0x555556d514f0 "GetPixelSpan", qname=0x0, fqname=0x0, sig=0x555556d54880,
    from_class=0x555556d292f0, ignore_cmods=1, error=0x7fffffffc810) at /home/jay/runtime/src/mono/mono/metadata/unsafe-accessor.c:59
#5  0x0000555555918ed6 in find_method_in_class_unsafe_accessor (klass=0x555556d292f0, name=0x555556d514f0 "GetPixelSpan", qname=0x0, fqname=0x0, sig=0x555556d54880,
    from_class=0x555556d292f0, ignore_cmods=1, error=0x7fffffffc810) at /home/jay/runtime/src/mono/mono/metadata/unsafe-accessor.c:155
#6  0x00005555559192f6 in mono_unsafe_accessor_find_method (in_class=0x555556d292f0, name=0x555556d514f0 "GetPixelSpan", sig=0x555556d54880, from_class=0x555556d292f0,
    error=0x7fffffffc810) at /home/jay/runtime/src/mono/mono/metadata/unsafe-accessor.c:212
#7  0x000055555573c7b6 in emit_unsafe_accessor_method_wrapper (mb=0x555556d548e0, accessor_method=0x555556b104e8, sig=0x555556d54858, ctx=0x0,
    kind=MONO_UNSAFE_ACCESSOR_METHOD, member_name=0x555556d514f0 "GetPixelSpan") at /home/jay/runtime/src/mono/mono/metadata/marshal-lightweight.c:2494
#8  0x0000555555739bb1 in emit_unsafe_accessor_wrapper_ilgen (mb=0x555556d548e0, accessor_method=0x555556b104e8, sig=0x555556d54858, ctx=0x0,
    kind=MONO_UNSAFE_ACCESSOR_METHOD, member_name=0x555556d514f0 "GetPixelSpan") at /home/jay/runtime/src/mono/mono/metadata/marshal-lightweight.c:2540
#9  0x000055555569b538 in mono_marshal_get_unsafe_accessor_wrapper (accessor_method=0x555556b104e8, kind=MONO_UNSAFE_ACCESSOR_METHOD,
    member_name=0x555556d514f0 "GetPixelSpan") at /home/jay/runtime/src/mono/mono/metadata/marshal.c:5165
#10 0x00005555557706c4 in add_full_aot_wrappers (acfg=0x5555565f87b0) at /home/jay/runtime/src/mono/mono/mini/aot-compiler.c:5267
#11 0x000055555576cb95 in add_wrappers (acfg=0x5555565f87b0) at /home/jay/runtime/src/mono/mono/mini/aot-compiler.c:5512
#12 0x000055555576886b in collect_methods (acfg=0x5555565f87b0) at /home/jay/runtime/src/mono/mono/mini/aot-compiler.c:13103
#13 0x0000555555763e5b in aot_assembly (ass=0x5555565f8390, jit_opts=374417919, aot_options=0x7fffffffd200) at /home/jay/runtime/src/mono/mono/mini/aot-compiler.c:15163
#14 0x0000555555761669 in mono_aot_assemblies (assemblies=0x5555565f7f30, nassemblies=1, jit_opts=374417919,
    aot_options=0x5555565798b0 "dedup-skip,llvmonly,asmonly,no-opt,static,direct-icalls,deterministic,nodebug,llvm-path=/home/jay/.uno/emsdk/emsdk-3.1.34/emsdk/upstream/bin,profile=/mnt/d/s/uno.github/uno.gallery/Uno.Gallery/obj/Rel"...) at /home/jay/runtime/src/mono/mono/mini/aot-compiler.c:15653
#15 0x000055555575a205 in main_thread_handler (user_data=0x7fffffffd660) at /home/jay/runtime/src/mono/mono/mini/driver.c:1425
#16 0x0000555555755976 in mono_main (argc=4, argv=0x7fffffffd7f8) at /home/jay/runtime/src/mono/mono/mini/driver.c:2668
#17 0x00005555555fde48 in mono_main_with_options (argc=5, argv=0x7fffffffd7f8) at /home/jay/runtime/src/mono/mono/mini/main.c:36
#18 0x00005555555fde12 in main (argc=5, argv=0x7fffffffd7f8) at /home/jay/runtime/src/mono/mono/mini/main.c:88
```
