### PR TITLE
feat(jiterp): reclaim WASM function-table slots on forced ALC unload

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     branches:
       - main
-      - release/* 
+      - release/*
+      # Stacked PRs targeting an in-flight feature branch must pass the same commit-format gate.
+      - dev/**
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -2,6 +2,9 @@ name: Conventional Commits
 
 on:
   pull_request:
+    # `edited` included so retargeting a PR (a base change only emits `edited`) re-runs the
+    # gate instead of leaving stale results attached — same reasoning as runtime-ci.yml.
+    types: [opened, synchronize, reopened, edited]
     branches:
       - main
       - release/*

--- a/.github/workflows/runtime-ci.yml
+++ b/.github/workflows/runtime-ci.yml
@@ -14,6 +14,12 @@ on:
       # Stacked PRs: run the full validation (incl. the test_loader_wasm gate) for PRs that
       # target an in-flight feature branch instead of main, so stacked work is compile- and
       # test-gated before the base PR merges.
+      #
+      # NOTE on enforcement: this trigger only SCHEDULES the checks. Mergify-performed merges
+      # of dev/** PRs are gated on ci_ok + the commit-format check (see .mergify.yml), but a
+      # manual merge-button press can only be blocked by a repository ruleset / branch
+      # protection on dev/** requiring the `ci_ok` check — that is an admin-side setting and
+      # cannot be expressed in this file.
       - dev/**
 
 env:

--- a/.github/workflows/runtime-ci.yml
+++ b/.github/workflows/runtime-ci.yml
@@ -5,9 +5,20 @@ on:
     branches:
       - main
       - release/**
-      
+      # Post-merge validation for stacked work: a merge INTO a dev/** base produces a new
+      # commit that no pull_request run has ever tested (PR checks validate a speculative
+      # merge against the base as it was at trigger time). This also runs on pushes to
+      # dev/** PR source branches — an accepted duplication cost, since publish/sign jobs
+      # are hard-gated to main/release pushes and cannot fire from here.
+      - dev/**
+
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    # `edited` matters for merge-gating: retargeting a PR (changing its base) only emits an
+    # `edited` event. Without it, an already-green PR retargeted to dev/** keeps its old
+    # checks — computed against a different base — and nothing revalidates the new merge
+    # result. Title/body edits also re-trigger; that cost is accepted so a retarget can
+    # never reuse stale results.
+    types: [opened, synchronize, reopened, closed, edited]
     branches:
       - main
       - release/**

--- a/.github/workflows/runtime-ci.yml
+++ b/.github/workflows/runtime-ci.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - main
       - release/**
+      # Stacked PRs: run the full validation (incl. the test_loader_wasm gate) for PRs that
+      # target an in-flight feature branch instead of main, so stacked work is compile- and
+      # test-gated before the base PR merges.
+      - dev/**
 
 env:
   DOTNETRUNTIME_COMMIT: 742e2f077a0c7d79bf57d6dd01d571a06f3a4738

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -28,6 +28,30 @@ pull_request_rules:
       merge:
         method: merge
 
+  - name: automatic strict merge for stacked PRs (base dev/**) gated on runtime CI and commit format
+    conditions:
+      # Stacked pull-requests target an in-flight dev/** feature branch instead of main.
+      # runtime-ci.yml schedules the full validation for these PRs; this rule makes the
+      # results an actual gate for Mergify-performed merges. NOTE: Mergify cannot block a
+      # manual merge-button press — only a repository ruleset / branch protection on dev/**
+      # requiring the `ci_ok` check can do that (admin-side setting, tracked in PR #167).
+      - base~=^dev/
+
+      # The runtime CI aggregate gate and the commit-format check must both succeed:
+      - check-success=ci_ok
+      - check-success=Validate for conventional commits
+
+      # Same review and labeling bar as the main-branch rule:
+      - "#approved-reviews-by>=2"
+      - "#changes-requested-reviews-by=0"
+      - label=ready-to-merge
+      - label!=do-not-merge/breaking-change
+      - label!=do-not-merge/work-in-progress
+
+    actions:
+      merge:
+        method: merge
+
   - name: automatic merge for allcontributors pull requests
     conditions:
       - author=allcontributors[bot]

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -41,6 +41,12 @@ pull_request_rules:
       - check-success=ci_ok
       - check-success=Validate for conventional commits
 
+      # Freshness: the checks above are only meaningful against the CURRENT base. A base
+      # branch that advanced after the checks ran would let stale green results merge an
+      # untested result, so the head must be even with its base. (Retargeting is covered
+      # separately: the workflows trigger on the `edited` PR event, which resets the checks.)
+      - "#commits-behind=0"
+
       # Same review and labeling bar as the main-branch rule:
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
@@ -55,6 +61,9 @@ pull_request_rules:
   - name: automatic merge for allcontributors pull requests
     conditions:
       - author=allcontributors[bot]
+      # Scoped to main so this rule can never bypass the dev/** stacked-PR gate above
+      # (allcontributors only ever touches the contributors table on the default branch).
+      - base=main
     actions:
       merge:
         method: merge

--- a/patches/0012-reclaim-jiterpreter-table-slots-on-forced-alc-unload.patch
+++ b/patches/0012-reclaim-jiterpreter-table-slots-on-forced-alc-unload.patch
@@ -44,9 +44,13 @@ upstream monotonic one.
     table slot back to the allocator, after which the still-live call
     site would dispatch to whichever trace was installed next. The
     sentinel is now -1, every traceInfo/slot operation is guarded on
-    traceIndex >= 0, and the sweep counts each sentinel pass in a
-    monotonic diagnostic so the lifecycle tests can prove the branch
-    executed.
+    traceIndex >= 0, and each sentinel pass is counted in a monotonic
+    diagnostic BY THE RECEIVING TS SIDE (mono_jiterp_record_no_trace_sweep
+    via cwraps, called only when the index that ARRIVED is negative) so
+    the lifecycle tests prove both that the branch executed and that
+    the negative sentinel actually crossed the ownership boundary -- a
+    caller-side count would keep incrementing even if the sentinel
+    value regressed to the aliasing 0.
   * New EMSCRIPTEN_KEEPALIVE mono_jiterp_free_table_entry(type, index)
     (jiterpreter.c, crossing the boundary via cwraps like the existing
     mono_jiterp_allocate_table_entry): validates that the index is a
@@ -83,7 +87,17 @@ upstream monotonic one.
     bounds check, so deriving the stat from it would count failed
     allocations and could read negative on an untouched table),
     current free count, monotonic total-freed, monotonic total-reused,
-    monotonic no-trace sentinel sweeps}. JiterpreterTableReclamationTests
+    monotonic boundary-observed no-trace sentinel sweeps}. A sibling
+    icall InternalRunJiterpreterTableSelfTest is the surface's one
+    deliberately MUTATING member: the kind-0 failed-allocation
+    exclusion is only observable at exhaustion, and the real trace
+    table is too large for a test to exhaust, so the self-test swaps a
+    private 3-slot window into the trace-table allocator state
+    (single-threaded, saved and restored exactly, verdict cached),
+    drives fill / failed over-capacity attempt / release / refused
+    double release / reuse through the REAL allocator entry points and
+    stats surface, and returns 0 or the first failed step.
+    JiterpreterTableReclamationTests
     drive repeated load / hot-loop / unload / force cycles against a
     trace-bait method added to the loader test assembly (pure int
     arithmetic, well above the 5000 hit-count threshold; trace
@@ -123,17 +137,17 @@ Fixes https://github.com/unoplatform/Uno.DotnetRuntime.WebAssembly/issues/166
 Refs dotnet/runtime#89980.
 ---
  .../tests/ForcedNativeUnloadTests.cs          |  15 +-
- .../tests/JiterpreterTableReclamationTests.cs | 443 ++++++++++++++++++
- .../TestClass.cs                              |  55 +++
+ .../tests/JiterpreterTableReclamationTests.cs | 507 ++++++++++++++++++
+ .../TestClass.cs                              |  55 ++
  .../tests/System.Runtime.Loader.Tests.csproj  |   1 +
- .../Loader/AssemblyLoadContext.Mono.cs        |  17 +
- src/mono/browser/runtime/cwraps.ts            |   3 +
- src/mono/browser/runtime/jiterpreter.ts       |  36 +-
- .../mono/metadata/assembly-load-context.c     |  31 ++
- src/mono/mono/metadata/icall-def.h            |   1 +
+ .../Loader/AssemblyLoadContext.Mono.cs        |  36 ++
+ src/mono/browser/runtime/cwraps.ts            |   6 +
+ src/mono/browser/runtime/jiterpreter.ts       |  44 +-
+ .../mono/metadata/assembly-load-context.c     |  51 ++
+ src/mono/mono/metadata/icall-def.h            |   2 +
  src/mono/mono/mini/interp/interp.c            |  20 +-
- src/mono/mono/mini/interp/jiterpreter.c       | 173 ++++++-
- 11 files changed, 771 insertions(+), 24 deletions(-)
+ src/mono/mono/mini/interp/jiterpreter.c       | 293 +++++++++-
+ 11 files changed, 1006 insertions(+), 24 deletions(-)
  create mode 100644 src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs
 
 diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
@@ -164,10 +178,10 @@ index a30a5a290..60708a1b5 100644
          {
 diff --git a/src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs b/src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs
 new file mode 100644
-index 000000000..ff6e02f70
+index 000000000..d50eecd26
 --- /dev/null
 +++ b/src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs
-@@ -0,0 +1,443 @@
+@@ -0,0 +1,507 @@
 +// Licensed to the .NET Foundation under one or more agreements.
 +// The .NET Foundation licenses this file to you under the MIT license.
 +
@@ -195,11 +209,16 @@ index 000000000..ff6e02f70
 +    ///   kind 1 = slots currently sitting on the free set
 +    ///   kind 2 = total slots ever released (monotonic)
 +    ///   kind 3 = total released slots ever reused by the allocator (monotonic)
-+    ///   kind 4 = no-trace sentinel sweeps (monotonic; methods freed without any trace entry
-+    ///            points — table-agnostic, queried via the trace table)
++    ///   kind 4 = no-trace sentinel sweeps (monotonic; counted at the TypeScript ownership
++    ///            boundary when the sweep RECEIVES a negative trace index, so a regression of
++    ///            the sentinel value itself is observable — table-agnostic, queried via the
++    ///            trace table)
 +    /// The bridge returns -1 whenever slot reclamation is unavailable (non-browser runtime,
 +    /// threads-enabled build) or the opt-in flag is absent, so the surface is as dark by default
-+    /// as the feature itself — which the tests assert too.
++    /// as the feature itself — which the tests assert too. A second bridge member,
++    /// RunJiterpreterTableSelfTest, is the surface's one deliberately mutating hook: it drives a
++    /// private allocator window to exhaustion natively (see its docs) because the kind-0
++    /// failed-allocation-exclusion contract is only observable at exhaustion.
 +    ///
 +    /// Determinism: the assertions deliberately avoid an exact next_index plateau. Trace entry
 +    /// points in default-ALC code (CoreLib, xunit) accumulate hit counts across cycles and can
@@ -248,6 +267,9 @@ index 000000000..ff6e02f70
 +        private static readonly MethodInfo s_getJiterpreterTableStat = typeof(AssemblyLoadContext)
 +            .GetMethod("GetJiterpreterTableStat", BindingFlags.NonPublic | BindingFlags.Static);
 +
++        private static readonly MethodInfo s_runJiterpreterTableSelfTest = typeof(AssemblyLoadContext)
++            .GetMethod("RunJiterpreterTableSelfTest", BindingFlags.NonPublic | BindingFlags.Static);
++
 +        private static bool FlagEnabled
 +        {
 +            get
@@ -265,13 +287,13 @@ index 000000000..ff6e02f70
 +
 +        private static bool BridgeMissing()
 +        {
-+            if (s_forceNativeUnload != null && s_getJiterpreterTableStat != null)
++            if (s_forceNativeUnload != null && s_getJiterpreterTableStat != null && s_runJiterpreterTableSelfTest != null)
 +            {
 +                return false;
 +            }
 +
 +            Assert.False(RequireBridge,
-+                "AssemblyLoadContext.ForceNativeUnload / GetJiterpreterTableStat is missing: the bridge was trimmed away, or the patch is not applied (trim/rooting regression).");
++                "AssemblyLoadContext.ForceNativeUnload / GetJiterpreterTableStat / RunJiterpreterTableSelfTest is missing: the bridge was trimmed away, or the patch is not applied (trim/rooting regression).");
 +            return true;
 +        }
 +
@@ -288,6 +310,12 @@ index 000000000..ff6e02f70
 +        }
 +
 +        private static int TraceStat(int kind) => Stat(TraceTable, kind);
++
++        private static int RunAllocatorSelfTest()
++        {
++            object result = s_runJiterpreterTableSelfTest.Invoke(null, null);
++            return Convert.ToInt32(result);
++        }
 +
 +        [MethodImpl(MethodImplOptions.NoInlining)]
 +        private static void GcQuiesce()
@@ -359,6 +387,51 @@ index 000000000..ff6e02f70
 +            // consumed a prior release.
 +            Assert.True(free <= fresh, $"slots on the free set ({free}) cannot exceed distinct slots ever handed out fresh ({fresh})");
 +            Assert.True(totalReused <= totalFreed, $"reuses ({totalReused}) cannot exceed releases ({totalFreed})");
++        }
++
++        /// <summary>
++        /// Deterministic exhaustion regression for the StatFreshAllocated (kind 0) contract:
++        /// failed allocations must not count as fresh hand-outs. Before the first over-capacity
++        /// attempt a next_index-derived stat and the dedicated success counter agree, and the
++        /// real trace table (thousands of slots) can never be driven to exhaustion by a test
++        /// without wrecking the suite — so the native side swaps a private 3-slot window into
++        /// the allocator (single-threaded, state saved and restored exactly; see
++        /// mono_jiterp_run_table_self_test), fills it, attempts one extra fresh allocation, and
++        /// verifies through the REAL stats surface that only the successful hand-outs were
++        /// counted, plus the release / double-release-refusal / reuse-before-growth invariants.
++        /// </summary>
++        [Fact]
++        public void JiterpreterTableAllocator_ExhaustionSelfTest()
++        {
++            if (BridgeMissing())
++            {
++                return;
++            }
++
++            int verdict = RunAllocatorSelfTest();
++
++            if (!FlagEnabled || PlatformDetection.IsThreadingSupported)
++            {
++                // Feature dark: the self-test must refuse to touch anything and report
++                // unavailable, exactly like the read-only stats.
++                Assert.Equal(-1, verdict);
++                return;
++            }
++
++            Assert.True(verdict == 0,
++                $"jiterpreter table allocator exhaustion self-test failed at step {verdict}: " + verdict switch
++                {
++                    1 => "the live trace table was not initialized yet",
++                    2 => "filling to capacity did not hand out every slot exactly once",
++                    3 => "allocation beyond capacity did not fail",
++                    4 => "a FAILED allocation was counted as a fresh hand-out (StatFreshAllocated contract broken)",
++                    5 => "releasing an allocated slot was refused",
++                    6 => "a double release was accepted",
++                    7 => "the released slot was not reused before fresh growth",
++                    8 => "a reuse was counted as a fresh hand-out",
++                    9 => "release/reuse totals were not exactly one each",
++                    _ => "unknown step",
++                });
 +        }
 +
 +        [Fact]
@@ -512,11 +585,16 @@ index 000000000..ff6e02f70
 +            LoadUnloadAndForceWithoutHotLoop();
 +
 +            // Non-vacuity: at least one swept method (the invoked no-trace bait's InterpMethod at
-+            // minimum) took the need_extra_free sentinel branch during the forced unload.
++            // minimum) drove a NEGATIVE sentinel index all the way to the TypeScript ownership
++            // boundary during the forced unload. Kind 4 counts on the RECEIVING side of
++            // mono_wasm_free_method_data, so this assertion fails both when the collectible
++            // InterpMethod never reaches the sweep AND when the native sentinel regresses to the
++            // aliasing 0 (the TS side then takes the per-trace path and never counts).
 +            Assert.True(TraceStat(StatNoTraceSweeps) > sentinelSweepsBefore,
-+                $"the forced unload must sweep the invoked trace-less method through the no-trace sentinel path " +
++                $"the forced unload must deliver the negative no-trace sentinel to the TS free boundary " +
 +                $"(noTraceSweeps before={sentinelSweepsBefore} after={TraceStat(StatNoTraceSweeps)}). " +
-+                "If the counter did not move, the collectible InterpMethod never reached the sweep and this test proved nothing.");
++                "If the counter did not move, either the collectible InterpMethod never reached the sweep " +
++                "or the sentinel value regressed to a non-negative index.");
 +
 +            // The regression itself: a sentinel sweep must not release anyone's slot — with the
 +            // old 0 sentinel it would have released the live trace-0 slot of a default-ALC method.
@@ -697,18 +775,19 @@ index bbdad35cc..09a06f1b3 100644
      <EmbeddedResource Include="MainStrings*.resx" />
    </ItemGroup>
 diff --git a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
-index cc30e0cdb..bf45b0438 100644
+index cc30e0cdb..88ce94a0c 100644
 --- a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
 +++ b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
-@@ -37,6 +37,7 @@ internal IntPtr NativeALC
+@@ -37,6 +37,8 @@ internal IntPtr NativeALC
          [DynamicDependency(nameof(_nativeAssemblyLoadContext))]
          [DynamicDependency(nameof(ForceNativeUnload))] // trim-root: hosts invoke this bridge via reflection
          [DynamicDependency(nameof(GetScoutRetirementStats))] // trim-root: diagnostics bridge, invoked via reflection
 +        [DynamicDependency(nameof(GetJiterpreterTableStat))] // trim-root: lifecycle tests invoke this bridge via reflection
++        [DynamicDependency(nameof(RunJiterpreterTableSelfTest))] // trim-root: lifecycle tests invoke this bridge via reflection
          private IntPtr InitializeAssemblyLoadContext(IntPtr thisHandlePtr, bool representsTPALoadContext, bool isCollectible)
          {
              if (isCollectible)
-@@ -78,6 +79,22 @@ private static void KeepLoaderAllocator()
+@@ -78,6 +80,40 @@ private static void KeepLoaderAllocator()
          // unconditional (not part of the DISABLE_THREADS-gated forced teardown).
          internal static int GetScoutRetirementStats(int kind) => InternalGetScoutRetirementStats(kind);
  
@@ -719,7 +798,8 @@ index cc30e0cdb..bf45b0438 100644
 +        // Mirrors mono_jiterp_get_table_stat (jiterpreter.c): `table` is a JITERPRETER_TABLE_*
 +        // value (0 = traces) and `kind` selects the statistic (0 = fresh slots successfully
 +        // handed out, 1 = slots currently free, 2 = total slots ever released, 3 = total released
-+        // slots ever reused, 4 = no-trace sentinel sweeps — all monotonic except 1).
++        // slots ever reused, 4 = no-trace sentinel sweeps as observed at the TypeScript ownership
++        // boundary — all monotonic except 1).
 +        // Returns -1 whenever slot reclamation is unavailable (non-browser runtime,
 +        // threads-enabled build) or the MONO_WASM_ENABLE_ALC_UNLOAD opt-in is absent, so this
 +        // surface is as dark by default as the feature it observes.
@@ -728,35 +808,55 @@ index cc30e0cdb..bf45b0438 100644
 +            return InternalGetJiterpreterTableStat(table, kind);
 +        }
 +
++        [MethodImplAttribute(MethodImplOptions.InternalCall)]
++        private static extern int InternalRunJiterpreterTableSelfTest();
++
++        // Deterministic exhaustion self-test for the reclamation allocator (see
++        // mono_jiterp_run_table_self_test in jiterpreter.c): swaps a private 3-slot window into
++        // the trace-table allocator, drives fill / failed over-capacity attempt / release /
++        // refused double release / reuse through the REAL allocator entry points, restores the
++        // live state exactly, and returns 0 when every invariant held, the failed step number
++        // otherwise, or -1 whenever the feature is unavailable or not opted in (same dark-by-
++        // default contract as GetJiterpreterTableStat). This is the only mutating member of the
++        // diagnostic bridge; the real table is too large for a test to reach exhaustion —
++        // where the kind-0 failed-allocation-exclusion contract becomes observable — any other way.
++        internal static int RunJiterpreterTableSelfTest()
++        {
++            return InternalRunJiterpreterTableSelfTest();
++        }
++
          // Outcome of a host-triggered native ALC teardown. The values MUST stay in sync with the
          // return codes of ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload
          // in the native assembly-load-context.c.
 diff --git a/src/mono/browser/runtime/cwraps.ts b/src/mono/browser/runtime/cwraps.ts
-index e693c5223..c02fbd777 100644
+index e693c5223..35680619a 100644
 --- a/src/mono/browser/runtime/cwraps.ts
 +++ b/src/mono/browser/runtime/cwraps.ts
-@@ -120,6 +120,7 @@ const fn_signatures: SigLine[] = [
+@@ -120,6 +120,8 @@ const fn_signatures: SigLine[] = [
      [true, "mono_jiterp_is_special_interface", "number", ["number"]],
      [true, "mono_jiterp_initialize_table", "void", ["number", "number", "number"]],
      [true, "mono_jiterp_allocate_table_entry", "number", ["number"]],
 +    [true, "mono_jiterp_free_table_entry", "number", ["number", "number"]],
++    [true, "mono_jiterp_record_no_trace_sweep", "void", []],
      [true, "mono_jiterp_get_interp_entry_func", "number", ["number"]],
      [true, "mono_jiterp_get_counter", "number", ["number"]],
      [true, "mono_jiterp_modify_counter", "number", ["number", "number"]],
-@@ -248,6 +249,8 @@ export interface t_Cwraps {
+@@ -248,6 +250,10 @@ export interface t_Cwraps {
      mono_jiterp_is_special_interface(klass: number): number;
      mono_jiterp_initialize_table(type: number, firstIndex: number, lastIndex: number): void;
      mono_jiterp_allocate_table_entry(type: number): number;
 +    // returns 1 when the slot was accepted for reuse (forced ALC unload reclamation), 0 when refused
 +    mono_jiterp_free_table_entry(type: number, index: number): number;
++    // diagnostic: the no-trace sentinel (a negative trace index) was observed at this boundary
++    mono_jiterp_record_no_trace_sweep(): void;
      mono_jiterp_get_interp_entry_func(type: number): number;
      mono_jiterp_get_counter(counter: number): number;
      mono_jiterp_modify_counter(counter: number, delta: number): number;
 diff --git a/src/mono/browser/runtime/jiterpreter.ts b/src/mono/browser/runtime/jiterpreter.ts
-index 6ba17a3ab..09ba3a418 100644
+index 6ba17a3ab..143cca64d 100644
 --- a/src/mono/browser/runtime/jiterpreter.ts
 +++ b/src/mono/browser/runtime/jiterpreter.ts
-@@ -1088,10 +1088,38 @@ export function mono_wasm_free_method_data (
+@@ -1088,10 +1088,46 @@ export function mono_wasm_free_method_data (
          mono_wasm_profiler_free_method(method);
      }
  
@@ -795,15 +895,23 @@ index 6ba17a3ab..09ba3a418 100644
 +        }
 +        // Release the trace info object, if present
 +        delete traceInfo[traceIndex];
++    } else {
++        // Diagnostic, counted HERE at the ownership boundary rather than by the native
++        //  caller: the lifecycle tests assert this counter moves when a trace-less method
++        //  is swept, proving a negative sentinel actually arrived. If the native sentinel
++        //  ever regressed to the aliasing 0 again, this branch would not be taken and the
++        //  counter would freeze — failing the test — whereas a caller-side count would
++        //  keep incrementing and mask the regression.
++        cwraps.mono_jiterp_record_no_trace_sweep();
 +    }
      // Remove any AOT data and queue entries associated with the method
      mono_jiterp_free_method_data_interp_entry(imethod);
      mono_jiterp_free_method_data_jit_call(method);
 diff --git a/src/mono/mono/metadata/assembly-load-context.c b/src/mono/mono/metadata/assembly-load-context.c
-index 382247fa9..206c1a653 100644
+index 382247fa9..d8eac6e34 100644
 --- a/src/mono/mono/metadata/assembly-load-context.c
 +++ b/src/mono/mono/metadata/assembly-load-context.c
-@@ -617,6 +617,37 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+@@ -617,6 +617,57 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
  #endif
  }
  
@@ -816,6 +924,8 @@ index 382247fa9..206c1a653 100644
 + */
 +extern gint32
 +mono_jiterp_get_table_stat (int table, int kind);
++extern gint32
++mono_jiterp_run_table_self_test (void);
 +#endif
 +
 +int
@@ -838,14 +948,32 @@ index 382247fa9..206c1a653 100644
 +#endif
 +}
 +
++int
++ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalRunJiterpreterTableSelfTest (MonoError *error)
++{
++	/*
++	 * Deterministic exhaustion self-test for the reclamation allocator (see
++	 * mono_jiterp_run_table_self_test in jiterpreter.c for the procedure, the
++	 * save/swap/restore safety argument, and the step-code meanings). The one
++	 * deliberately mutating member of this diagnostic surface — justified there —
++	 * and gated exactly like the rest: -1 on non-browser runtimes, threads-enabled
++	 * builds, or without the MONO_WASM_ENABLE_ALC_UNLOAD opt-in.
++	 */
++#if defined(HOST_BROWSER) && defined(DISABLE_THREADS)
++	return mono_jiterp_run_table_self_test ();
++#else
++	return -1;
++#endif
++}
++
  gpointer
  ves_icall_System_Runtime_Loader_AssemblyLoadContext_GetLoadContextForAssembly (MonoReflectionAssemblyHandle assm_obj, MonoError *error)
  {
 diff --git a/src/mono/mono/metadata/icall-def.h b/src/mono/mono/metadata/icall-def.h
-index 4e1a93423..e4ca6f1d6 100644
+index 4e1a93423..340ea5384 100644
 --- a/src/mono/mono/metadata/icall-def.h
 +++ b/src/mono/mono/metadata/icall-def.h
-@@ -473,6 +473,7 @@ NOHANDLES(ICALL(X86BASE_1, "__cpuidex", ves_icall_System_Runtime_Intrinsics_X86_
+@@ -473,11 +473,13 @@ NOHANDLES(ICALL(X86BASE_1, "__cpuidex", ves_icall_System_Runtime_Intrinsics_X86_
  ICALL_TYPE(ALC, "System.Runtime.Loader.AssemblyLoadContext", ALC_5)
  HANDLES(ALC_5, "GetLoadContextForAssembly", ves_icall_System_Runtime_Loader_AssemblyLoadContext_GetLoadContextForAssembly, gpointer, 1, (MonoReflectionAssembly))
  HANDLES(ALC_7, "InternalForceNativeUnload", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload, int, 1, (gpointer))
@@ -853,6 +981,12 @@ index 4e1a93423..e4ca6f1d6 100644
  HANDLES(ALC_4, "InternalGetLoadedAssemblies", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetLoadedAssemblies, MonoArray, 0, ())
  HANDLES(ALC_8, "InternalGetScoutRetirementStats", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementStats, int, 1, (gint32))
  HANDLES(ALC_2, "InternalInitializeNativeALC", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalInitializeNativeALC, gpointer, 4, (gpointer, const_char_ptr, MonoBoolean, MonoBoolean))
+ HANDLES(ALC_1, "InternalLoadFile", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalLoadFile, MonoReflectionAssembly, 3, (gpointer, MonoString, MonoStackCrawlMark_ptr))
+ HANDLES(ALC_3, "InternalLoadFromStream", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalLoadFromStream, MonoReflectionAssembly, 5, (gpointer, gpointer, gint32, gpointer, gint32))
++HANDLES(ALC_10, "InternalRunJiterpreterTableSelfTest", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalRunJiterpreterTableSelfTest, int, 0, ())
+ HANDLES(ALC_6, "PrepareForAssemblyLoadContextRelease", ves_icall_System_Runtime_Loader_AssemblyLoadContext_PrepareForAssemblyLoadContextRelease, void, 2, (gpointer, gpointer))
+ 
+ ICALL_TYPE(RFH, "System.RuntimeFieldHandle", RFH_1)
 diff --git a/src/mono/mono/mini/interp/interp.c b/src/mono/mono/mini/interp/interp.c
 index a47d81246..4db8b85bd 100644
 --- a/src/mono/mono/mini/interp/interp.c
@@ -885,30 +1019,42 @@ index a47d81246..4db8b85bd 100644
  void
  mono_interp_free_mem_manager_jiterp (MonoJitMemoryManager *jit_mm)
 diff --git a/src/mono/mono/mini/interp/jiterpreter.c b/src/mono/mono/mini/interp/jiterpreter.c
-index 887038ca4..6e26e4499 100644
+index 887038ca4..f5ee263cd 100644
 --- a/src/mono/mono/mini/interp/jiterpreter.c
 +++ b/src/mono/mono/mini/interp/jiterpreter.c
-@@ -946,6 +946,19 @@ mono_interp_tier_prepare_jiterpreter_fast (
+@@ -946,6 +946,31 @@ mono_interp_tier_prepare_jiterpreter_fast (
  	}
  }
  
 +#ifdef DISABLE_THREADS
 +/*
-+ * Monotonic count of no-trace sentinel sweeps: how many times the need_extra_free branch
-+ * below passed -1 to mono_wasm_free_method_data because the method being freed contained
-+ * no trace entry points. Exposed as kind 4 of mono_jiterp_get_table_stat so the lifecycle
-+ * tests can prove the sentinel path actually executed for a swept method (an empty
-+ * interp_code_hash would otherwise make the "no slot was released" assertion vacuous).
-+ * Part of the DISABLE_THREADS-gated reclamation diagnostics; see the state block above
-+ * mono_jiterp_free_table_entry further down.
++ * Monotonic count of no-trace sentinel sweeps AS OBSERVED AT THE TYPESCRIPT OWNERSHIP
++ * BOUNDARY: the TS side of the per-method sweep (mono_wasm_free_method_data in
++ * jiterpreter.ts) calls mono_jiterp_record_no_trace_sweep below when — and only when —
++ * the trace index it RECEIVED is negative. Exposed as kind 4 of mono_jiterp_get_table_stat
++ * so the lifecycle tests can prove the sentinel path actually executed for a swept method
++ * (an empty interp_code_hash would otherwise make the "no slot was released" assertion
++ * vacuous). Counting on the receiving side of the boundary is deliberate: incrementing in
++ * the need_extra_free branch itself, before the call, would keep counting even if the
++ * sentinel value regressed from -1 back to the aliasing 0 — the exact production bug this
++ * counter's test guards — whereas here that regression freezes the counter and fails the
++ * named test. Part of the DISABLE_THREADS-gated reclamation diagnostics; see the state
++ * block above mono_jiterp_free_table_entry further down.
 + */
 +static gint32 jiterp_no_trace_sweep_count = 0;
 +#endif
 +
++EMSCRIPTEN_KEEPALIVE void
++mono_jiterp_record_no_trace_sweep (void) {
++#ifdef DISABLE_THREADS
++	jiterp_no_trace_sweep_count++;
++#endif
++}
++
  void
  mono_jiterp_free_method_data (MonoMethod *method, InterpMethod *imethod)
  {
-@@ -988,7 +1001,13 @@ mono_jiterp_free_method_data (MonoMethod *method, InterpMethod *imethod)
+@@ -988,7 +1013,13 @@ mono_jiterp_free_method_data (MonoMethod *method, InterpMethod *imethod)
  	if (need_extra_free) {
  		// HACK: Perform a single free operation to clear out any stuff from the jit queues
  		// This will happen if we didn't encounter any jiterpreter traces in the method
@@ -916,14 +1062,14 @@ index 887038ca4..6e26e4499 100644
 +		// Pass -1, NOT 0: trace indexes are allocated from zero (trace_count++), so 0 is a
 +		// real trace that very likely belongs to a live method in another (default) ALC.
 +		// The JS side treats a negative index as "no trace" and skips all per-trace work.
-+#ifdef DISABLE_THREADS
-+		jiterp_no_trace_sweep_count++;
-+#endif
++		// (The sentinel-sweep diagnostic is counted by the RECEIVING side — see
++		// mono_jiterp_record_no_trace_sweep above — so a regression of this value is
++		// observable at the ownership boundary rather than masked by a caller-side count.)
 +		mono_wasm_free_method_data (method, imethod, -1);
  	}
  }
  
-@@ -1476,6 +1495,55 @@ mono_jiterp_is_imethod_var_address_taken (InterpMethod *imethod, int offset) {
+@@ -1476,6 +1507,55 @@ mono_jiterp_is_imethod_var_address_taken (InterpMethod *imethod, int offset) {
  JiterpreterTableInfo tables[JITERPRETER_TABLE_LAST + 1] = { 0 };
  int mono_jiterp_first_trace_fn_ptr = 0;
  
@@ -979,7 +1125,7 @@ index 887038ca4..6e26e4499 100644
  static void
  atomically_set_value_once (gint32 *address, gint32 value) {
  #ifdef DISABLE_THREADS
-@@ -1530,6 +1598,17 @@ mono_jiterp_allocate_table_entry (int type) {
+@@ -1530,6 +1610,17 @@ mono_jiterp_allocate_table_entry (int type) {
  #ifdef DISABLE_THREADS
  	if (table->next_index == 0)
  		table->next_index = table->first_index;
@@ -997,7 +1143,7 @@ index 887038ca4..6e26e4499 100644
  	int index = table->next_index++;
  #else
  	gint32 expected = 0;
-@@ -1543,9 +1622,101 @@ mono_jiterp_allocate_table_entry (int type) {
+@@ -1543,9 +1634,209 @@ mono_jiterp_allocate_table_entry (int type) {
  			g_printf ("MONO_WASM: Jiterpreter table %d is out of space (%d entries allocated)\n", type, index - table->first_index + 1);
  		return 0;
  	}
@@ -1064,9 +1210,11 @@ index 887038ca4..6e26e4499 100644
 + *   1 = slots currently sitting on the free set
 + *   2 = total slots ever released (monotonic)
 + *   3 = total released slots ever reused by the allocator (monotonic)
-+ *   4 = no-trace sentinel sweeps (monotonic; how often mono_jiterp_free_method_data freed
-+ *       a method with no trace entry points — table-agnostic, but still requires a valid
-+ *       table so the invalid-argument probes stay uniform; query it via the trace table)
++ *   4 = no-trace sentinel sweeps (monotonic; how often the TS side of the sweep RECEIVED a
++ *       negative trace index — counted at the ownership boundary via
++ *       mono_jiterp_record_no_trace_sweep, so a sentinel-value regression freezes it.
++ *       Table-agnostic, but still requires a valid table so the invalid-argument probes
++ *       stay uniform; query it via the trace table)
 + */
 +gint32
 +mono_jiterp_get_table_stat (int type, int kind) {
@@ -1093,6 +1241,112 @@ index 887038ca4..6e26e4499 100644
 +		default:
 +			return -1;
 +	}
++#endif
++}
++
++/*
++ * Deterministic exhaustion self-test for the reclamation allocator, reached through the
++ * InternalRunJiterpreterTableSelfTest icall. This is the one deliberately MUTATING member
++ * of the diagnostics surface (mono_jiterp_get_table_stat stays read-only): the real trace
++ * table holds thousands of slots, so no lifecycle test can drive it to exhaustion without
++ * wrecking the rest of the suite — yet the failed-allocation-exclusion contract of stat
++ * kind 0 only becomes observable AT exhaustion (before the first over-capacity attempt, a
++ * next_index-derived stat and the dedicated success counter agree). So this hook swaps a
++ * private 3-slot window into the trace table's allocator state, drives the REAL entry
++ * points (mono_jiterp_allocate_table_entry / mono_jiterp_free_table_entry /
++ * mono_jiterp_get_table_stat) through fill -> failed over-capacity attempt -> release ->
++ * refused double release -> reuse, and restores the saved state exactly before returning.
++ * Safe by the same hard gate as everything here: single-threaded build (nothing can
++ * interleave with the swap) plus the MONO_WASM_ENABLE_ALC_UNLOAD opt-in; without both it
++ * reports -1 and touches nothing. The verdict is cached so reruns cannot double-apply.
++ * (The over-capacity attempt logs one benign "Jiterpreter table 0 is out of space (4
++ * entries allocated)" line — that is the upstream allocator's own diagnostic firing on the
++ * private window.)
++ *
++ * Returns -1 when unavailable/not opted in, 0 when every invariant held, or the number of
++ * the first failed step:
++ *   1 = live trace table not initialized yet (cannot swap safely)
++ *   2 = filling to capacity did not hand out every slot exactly once
++ *   3 = allocation beyond capacity did not fail
++ *   4 = the failed attempt was counted as a fresh hand-out (stat kind 0 contract broken)
++ *   5 = releasing an allocated slot was refused
++ *   6 = a double release was accepted
++ *   7 = the released slot was not reused before fresh growth
++ *   8 = the reuse was counted as a fresh hand-out
++ *   9 = release/reuse totals are not exactly one each
++ */
++gint32
++mono_jiterp_run_table_self_test (void) {
++#ifndef DISABLE_THREADS
++	return -1;
++#else
++	if (!jiterp_table_reclamation_enabled ())
++		return -1;
++
++	static gint32 cached_verdict = -2;
++	if (cached_verdict != -2)
++		return cached_verdict;
++
++	const int type = JITERPRETER_TABLE_TRACE;
++	JiterpreterTableInfo *table = &tables [type];
++	if (table->first_index <= 0) {
++		cached_verdict = 1;
++		return cached_verdict;
++	}
++
++	// Save the complete live allocator state for the table.
++	JiterpreterTableInfo saved_table = *table;
++	MonoBitSet *saved_free_slots = table_free_slots [type];
++	gint32 saved_free_count = table_free_counts [type];
++	gint32 saved_total_freed = table_total_freed [type];
++	gint32 saved_total_reused = table_total_reused [type];
++	gint32 saved_fresh = table_fresh_allocated [type];
++
++	// Install a private 3-slot window. Indexes 2..4 look like real allocations (above the
++	// TRAINING/NOT_JITTED sentinel values 0/1) but are never installed into the WASM
++	// function table — the self-test only exercises allocator bookkeeping.
++	table->first_index = 2;
++	table->last_index = 4;
++	table->next_index = 2;
++	table_free_slots [type] = NULL;
++	table_free_counts [type] = 0;
++	table_total_freed [type] = 0;
++	table_total_reused [type] = 0;
++	table_fresh_allocated [type] = 0;
++
++	gint32 verdict = 0;
++	int a1 = mono_jiterp_allocate_table_entry (type);
++	int a2 = mono_jiterp_allocate_table_entry (type);
++	int a3 = mono_jiterp_allocate_table_entry (type);
++	if (a1 != 2 || a2 != 3 || a3 != 4)
++		verdict = 2;
++	if (!verdict && mono_jiterp_allocate_table_entry (type) != 0)
++		verdict = 3;
++	if (!verdict && mono_jiterp_get_table_stat (type, 0) != 3)
++		verdict = 4;
++	if (!verdict && mono_jiterp_free_table_entry (type, a2) != 1)
++		verdict = 5;
++	if (!verdict && mono_jiterp_free_table_entry (type, a2) != 0)
++		verdict = 6;
++	if (!verdict && mono_jiterp_allocate_table_entry (type) != a2)
++		verdict = 7;
++	if (!verdict && mono_jiterp_get_table_stat (type, 0) != 3)
++		verdict = 8;
++	if (!verdict && (mono_jiterp_get_table_stat (type, 2) != 1 || mono_jiterp_get_table_stat (type, 3) != 1))
++		verdict = 9;
++
++	// Tear down the window's bitset and restore the live state exactly.
++	if (table_free_slots [type])
++		mono_bitset_free (table_free_slots [type]);
++	*table = saved_table;
++	table_free_slots [type] = saved_free_slots;
++	table_free_counts [type] = saved_free_count;
++	table_total_freed [type] = saved_total_freed;
++	table_total_reused [type] = saved_total_reused;
++	table_fresh_allocated [type] = saved_fresh;
++
++	cached_verdict = verdict;
++	return cached_verdict;
 +#endif
 +}
 +

--- a/patches/0012-reclaim-jiterpreter-table-slots-on-forced-alc-unload.patch
+++ b/patches/0012-reclaim-jiterpreter-table-slots-on-forced-alc-unload.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nick Randolph <noreply@platform.uno>
-Date: Wed, 5 Aug 2026 00:00:00 +0000
+Date: Wed, 12 Aug 2026 00:00:00 +0000
 Subject: [PATCH] feat: reclaim jiterpreter WASM function-table slots on forced
  ALC unload
 
@@ -34,6 +34,19 @@ upstream monotonic one.
     mono_jiterp_free_method_data) on forced unload, and by
     interp_free_method for dynamic methods. That callback now offers
     the recorded slot back to the runtime.
+  * No-trace sentinel: mono_jiterp_free_method_data calls
+    mono_wasm_free_method_data once with a sentinel index when a
+    method has no trace entry points, purely to drain the general JIT
+    queues. That sentinel was 0 -- but trace indexes are allocated
+    from zero, so 0 aliases a real trace that typically belongs to a
+    live default-ALC method. Upstream that only dropped the wrong
+    traceInfo entry; with slot reclamation it would also hand a LIVE
+    table slot back to the allocator, after which the still-live call
+    site would dispatch to whichever trace was installed next. The
+    sentinel is now -1, every traceInfo/slot operation is guarded on
+    traceIndex >= 0, and the sweep counts each sentinel pass in a
+    monotonic diagnostic so the lifecycle tests can prove the branch
+    executed.
   * New EMSCRIPTEN_KEEPALIVE mono_jiterp_free_table_entry(type, index)
     (jiterpreter.c, crossing the boundary via cwraps like the existing
     mono_jiterp_allocate_table_entry): validates that the index is a
@@ -65,22 +78,33 @@ upstream monotonic one.
     icall InternalGetJiterpreterTableStat (on the same internal type
     as InternalForceNativeUnload; returns -1 whenever reclamation is
     unavailable or not opted in, so the surface is as dark as the
-    feature) exposes per-table {fresh next_index allocations, current
-    free count, monotonic total-freed, monotonic total-reused}. New
-    JiterpreterTableReclamationTests drive repeated
-    load / hot-loop / unload / force cycles against a trace-bait
-    method added to the loader test assembly (pure int arithmetic,
-    well above the 5000 hit-count threshold; trace compilation is
-    synchronous at the threshold on the single-threaded runtime) and
-    assert (a) every cycle's forced unload increases total-freed and
-    (b) released slots are consumed by later allocations
-    (total-reused increases). The assertions intentionally use the
-    monotonic counters, NOT an exact next_index plateau: trace entry
-    points in default-ALC code (CoreLib/xunit) accumulate hit counts
-    across cycles and can compile at unpredictable moments, so a
-    plateau assertion would be flaky while the counter assertions
-    cannot be. With the flag off the tests assert the surface stays
-    dark (stats -1, force Rejected) -- the zero-change guarantee.
+    feature) exposes per-table {successful fresh allocations (a
+    dedicated counter -- next_index advances before the allocator's
+    bounds check, so deriving the stat from it would count failed
+    allocations and could read negative on an untouched table),
+    current free count, monotonic total-freed, monotonic total-reused,
+    monotonic no-trace sentinel sweeps}. JiterpreterTableReclamationTests
+    drive repeated load / hot-loop / unload / force cycles against a
+    trace-bait method added to the loader test assembly (pure int
+    arithmetic, well above the 5000 hit-count threshold; trace
+    compilation is synchronous at the threshold on the single-threaded
+    runtime): after warm-up cycles seed the free set and drain the
+    harness's one-time compilations, every measured cycle must
+    increase total-freed AND total-reused, and the window's NET
+    capacity consumption (fresh + reused allocations minus releases)
+    must stay below one slot per cycle -- an identity that is
+    independent of free-set buffering, so a sweep that leaks even one
+    slot category per cycle fails it while bounded one-time
+    default-ALC compilations do not. A separate regression proves the
+    no-trace sentinel sweep is exercised for real: it invokes a
+    deliberately jiterpreter-ineligible collectible method once
+    (creating an InterpMethod in the collectible memory manager
+    without any trace entry points), asserts the sentinel-sweep
+    counter moved during the forced unload, and asserts total-freed
+    did not -- with the old 0 sentinel that sweep would have released
+    the live trace-0 slot of a default-ALC method. With the flag off
+    the tests assert the surface stays dark (stats -1, force Rejected)
+    -- the zero-change guarantee.
 
 SCOPE / still not covered: only JITERPRETER_TABLE_TRACE slots are ever
 released (the sweep only knows trace ownership). The jit-call and
@@ -94,37 +118,26 @@ for default consumers.
 
 Fixes https://github.com/unoplatform/Uno.DotnetRuntime.WebAssembly/issues/166
 Refs dotnet/runtime#89980.
-
- * No-trace sentinel: mono_jiterp_free_method_data calls
- *   mono_wasm_free_method_data once with a sentinel index when a method has no
- *   trace entry points, purely to drain the general JIT queues. That sentinel was
- *   0 -- but trace indexes are allocated from zero, so 0 aliases a real trace that
- *   typically belongs to a live default-ALC method. Upstream that only dropped the
- *   wrong traceInfo entry; with slot reclamation it would also hand a LIVE table
- *   slot back to the allocator, after which the still-live call site would dispatch
- *   to whichever trace was installed next. The sentinel is now -1 and every
- *   traceInfo/slot operation is guarded on traceIndex >= 0.
-
 ---
  .../tests/ForcedNativeUnloadTests.cs          |  15 +-
- .../tests/JiterpreterTableReclamationTests.cs | 304 ++++++++++++++++++
- .../TestClass.cs                              |  34 ++
+ .../tests/JiterpreterTableReclamationTests.cs | 440 ++++++++++++++++++
+ .../TestClass.cs                              |  46 ++
  .../tests/System.Runtime.Loader.Tests.csproj  |   1 +
- .../Loader/AssemblyLoadContext.Mono.cs        |  16 +
+ .../Loader/AssemblyLoadContext.Mono.cs        |  17 +
  src/mono/browser/runtime/cwraps.ts            |   3 +
- src/mono/browser/runtime/jiterpreter.ts       |  22 +-
+ src/mono/browser/runtime/jiterpreter.ts       |  36 +-
  .../mono/metadata/assembly-load-context.c     |  31 ++
  src/mono/mono/metadata/icall-def.h            |   1 +
  src/mono/mono/mini/interp/interp.c            |  20 +-
- src/mono/mono/mini/interp/jiterpreter.c       | 133 ++++++++
- 11 files changed, 559 insertions(+), 21 deletions(-)
+ src/mono/mono/mini/interp/jiterpreter.c       | 173 ++++++-
+ 11 files changed, 759 insertions(+), 24 deletions(-)
  create mode 100644 src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs
 
 diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
-index efaaffd..89b4c64 100644
+index a30a5a290..60708a1b5 100644
 --- a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 +++ b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
-@@ -174,16 +174,11 @@ namespace System.Runtime.Loader.Tests
+@@ -196,16 +196,11 @@ private static async Task<int> ForceUntilCompletedAsync(AssemblyLoadContext cont
              return outcome;
          }
  
@@ -144,14 +157,14 @@ index efaaffd..89b4c64 100644
 +        // by JiterpreterTableReclamationTests via the GetJiterpreterTableStat diagnostic bridge.
 +        // This suite keeps asserting the teardown protocol only.
          [Fact]
-         public void RepeatedForcedUnload_DoesNotCrash_IsIdempotent_AndAlcIsCollectible()
+         public async Task RepeatedForcedUnload_DoesNotCrash_IsIdempotent_AndAlcIsCollectible()
          {
 diff --git a/src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs b/src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs
 new file mode 100644
-index 0000000..e9abe36
+index 000000000..62275c790
 --- /dev/null
 +++ b/src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs
-@@ -0,0 +1,365 @@
+@@ -0,0 +1,440 @@
 +// Licensed to the .NET Foundation under one or more agreements.
 +// The .NET Foundation licenses this file to you under the MIT license.
 +
@@ -174,23 +187,33 @@ index 0000000..e9abe36
 +    ///
 +    /// Measurement goes through the diagnostic bridge AssemblyLoadContext.GetJiterpreterTableStat
 +    /// (table, kind), which surfaces per-table counters from the native allocator:
-+    ///   kind 0 = fresh slots handed out by advancing next_index (excludes reused slots)
++    ///   kind 0 = fresh slots successfully handed out (monotonic; excludes reused slots AND
++    ///            failed allocations — a dedicated counter, never derived from next_index)
 +    ///   kind 1 = slots currently sitting on the free set
 +    ///   kind 2 = total slots ever released (monotonic)
 +    ///   kind 3 = total released slots ever reused by the allocator (monotonic)
++    ///   kind 4 = no-trace sentinel sweeps (monotonic; methods freed without any trace entry
++    ///            points — table-agnostic, queried via the trace table)
 +    /// The bridge returns -1 whenever slot reclamation is unavailable (non-browser runtime,
 +    /// threads-enabled build) or the opt-in flag is absent, so the surface is as dark by default
 +    /// as the feature itself — which the tests assert too.
 +    ///
 +    /// Determinism: the assertions deliberately avoid an exact next_index plateau. Trace entry
 +    /// points in default-ALC code (CoreLib, xunit) accumulate hit counts across cycles and can
-+    /// cross the compile threshold at unpredictable moments, so next_index may legitimately
-+    /// creep. Instead the tests assert the two facts that cannot be timing-dependent on the
-+    /// single-threaded runtime (where trace compilation is synchronous at the hit threshold):
++    /// cross the compile threshold at unpredictable moments, so fresh allocations may
++    /// legitimately creep by a bounded amount. Instead the tests assert facts that cannot be
++    /// timing-dependent on the single-threaded runtime (where trace compilation is synchronous
++    /// at the hit threshold):
 +    ///   * every forced-unload cycle of a context that provably compiled a trace increases the
-+    ///     monotonic total-freed counter (the release happened), and
-+    ///   * after slots have been released, a later allocation consumes one (the monotonic
-+    ///     total-reused counter moves), because the allocator always prefers the free set.
++    ///     monotonic total-freed counter (the release happened),
++    ///   * once slots have been released, every later cycle's allocations consume the free set
++    ///     first (the monotonic total-reused counter moves each measured cycle), and
++    ///   * across the whole measured window, NET table-capacity consumption
++    ///     (fresh + reused allocations, minus releases) stays below one slot per cycle. This
++    ///     identity is buffer-independent: an unload sweep that misses even one slot category
++    ///     consumes at least one net slot EVERY cycle no matter how large the free set is, while
++    ///     a correct sweep's net consumption is only the one-time default-ALC compilations that
++    ///     are live by design — drained by the warm-up cycles before the window opens.
 +    /// </summary>
 +    [Collection(nameof(DisableParallelization))]
 +    public class JiterpreterTableReclamationTests
@@ -206,6 +229,7 @@ index 0000000..e9abe36
 +        private const int StatFreeCount = 1;
 +        private const int StatTotalFreed = 2;
 +        private const int StatTotalReused = 3;
++        private const int StatNoTraceSweeps = 4;
 +
 +        // Outcome codes; MUST match AssemblyLoadContext.ForceNativeUnloadResult.
 +        private const int Completed = 0;
@@ -311,6 +335,7 @@ index 0000000..e9abe36
 +                Assert.Equal(-1, TraceStat(StatFreeCount));
 +                Assert.Equal(-1, TraceStat(StatTotalFreed));
 +                Assert.Equal(-1, TraceStat(StatTotalReused));
++                Assert.Equal(-1, TraceStat(StatNoTraceSweeps));
 +                return;
 +            }
 +
@@ -319,11 +344,13 @@ index 0000000..e9abe36
 +            int free = TraceStat(StatFreeCount);
 +            int totalFreed = TraceStat(StatTotalFreed);
 +            int totalReused = TraceStat(StatTotalReused);
++            int noTraceSweeps = TraceStat(StatNoTraceSweeps);
 +
 +            Assert.True(fresh >= 0, $"fresh allocation count must be available with the opt-in active (got {fresh})");
 +            Assert.True(free >= 0, $"free count must be available with the opt-in active (got {free})");
 +            Assert.True(totalFreed >= 0, $"total-freed must be available with the opt-in active (got {totalFreed})");
 +            Assert.True(totalReused >= 0, $"total-reused must be available with the opt-in active (got {totalReused})");
++            Assert.True(noTraceSweeps >= 0, $"no-trace sweep count must be available with the opt-in active (got {noTraceSweeps})");
 +
 +            // Only distinct previously-allocated slots can sit on the free set, and every reuse
 +            // consumed a prior release.
@@ -348,37 +375,73 @@ index 0000000..e9abe36
 +                return;
 +            }
 +
-+            const int Cycles = 3;
-+            int reusedAtStart = TraceStat(StatTotalReused);
-+            var refs = new WeakReference[Cycles];
++            // Warm-up cycles are not measured: they let the collectible workload seed the free
++            // set AND let the surrounding harness paths (xunit dispatch, reflection invoke) cross
++            // their one-time trace compile thresholds, so the measured window below sees only the
++            // steady state. Each warm-up unload must still release at least one slot — that is
++            // this feature's core promise and needs no steady state.
++            const int WarmupCycles = 2;
++            const int MeasuredCycles = 4;
++            var refs = new WeakReference[WarmupCycles + MeasuredCycles];
 +
-+            for (int i = 0; i < Cycles; i++)
++            for (int i = 0; i < WarmupCycles; i++)
 +            {
 +                int freedBefore = TraceStat(StatTotalFreed);
 +                refs[i] = LoadRunHotLoopUnloadAndForce();
-+                int freedAfter = TraceStat(StatTotalFreed);
-+
-+                // The hot loop provably crossed the trace compile threshold inside the
-+                // collectible assembly (compilation is synchronous on this runtime), so the
-+                // forced teardown must have released at least one trace-table slot. total-freed
-+                // is monotonic, so no concurrent allocation can mask the release.
-+                Assert.True(freedAfter > freedBefore,
-+                    $"cycle {i}: the forced unload must release at least one jiterpreter trace-table slot " +
-+                    $"(totalFreed before={freedBefore} after={freedAfter}, fresh={TraceStat(StatFreshAllocated)}, " +
++                Assert.True(TraceStat(StatTotalFreed) > freedBefore,
++                    $"warm-up cycle {i}: the forced unload must release at least one jiterpreter trace-table slot " +
++                    $"(totalFreed before={freedBefore} after={TraceStat(StatTotalFreed)}, fresh={TraceStat(StatFreshAllocated)}, " +
 +                    $"free={TraceStat(StatFreeCount)}, totalReused={TraceStat(StatTotalReused)}). " +
 +                    "If totalFreed did not move, either no trace was compiled for the hot loop (jiterpreter disabled in this host?) " +
 +                    "or the unload sweep failed to release the trace's slot.");
 +            }
 +
-+            // Reuse: after the first cycle released slot(s), the free set was non-empty, and the
-+            // allocator always prefers it — so the later cycles' guaranteed trace compilations
-+            // (or any interleaved allocation) must have consumed released slots. total-reused is
-+            // monotonic, making this deterministic without asserting an exact plateau.
-+            int reusedAtEnd = TraceStat(StatTotalReused);
-+            Assert.True(reusedAtEnd > reusedAtStart,
-+                $"released trace-table slots must be reused by later allocations before fresh capacity is consumed " +
-+                $"(totalReused start={reusedAtStart} end={reusedAtEnd}, fresh={TraceStat(StatFreshAllocated)}, " +
-+                $"free={TraceStat(StatFreeCount)}, totalFreed={TraceStat(StatTotalFreed)}).");
++            int freshAtStart = TraceStat(StatFreshAllocated);
++            int reusedAtStart = TraceStat(StatTotalReused);
++            int freedAtStart = TraceStat(StatTotalFreed);
++
++            for (int i = 0; i < MeasuredCycles; i++)
++            {
++                int freedBefore = TraceStat(StatTotalFreed);
++                int reusedBefore = TraceStat(StatTotalReused);
++                refs[WarmupCycles + i] = LoadRunHotLoopUnloadAndForce();
++
++                // The hot loop provably crossed the trace compile threshold inside the
++                // collectible assembly (compilation is synchronous on this runtime), so the
++                // forced teardown must have released at least one trace-table slot. total-freed
++                // is monotonic, so no concurrent allocation can mask the release.
++                Assert.True(TraceStat(StatTotalFreed) > freedBefore,
++                    $"cycle {i}: the forced unload must release at least one jiterpreter trace-table slot " +
++                    $"(totalFreed before={freedBefore} after={TraceStat(StatTotalFreed)}, fresh={TraceStat(StatFreshAllocated)}, " +
++                    $"free={TraceStat(StatFreeCount)}, totalReused={TraceStat(StatTotalReused)}).");
++
++                // The previous cycle's sweep left the free set non-empty and the allocator always
++                // prefers it, so this cycle's guaranteed trace compilation must have consumed a
++                // released slot — every measured cycle, not just once per run.
++                Assert.True(TraceStat(StatTotalReused) > reusedBefore,
++                    $"cycle {i}: released trace-table slots must be reused before fresh capacity is consumed " +
++                    $"(totalReused before={reusedBefore} after={TraceStat(StatTotalReused)}, fresh={TraceStat(StatFreshAllocated)}, " +
++                    $"free={TraceStat(StatFreeCount)}, totalFreed={TraceStat(StatTotalFreed)}).");
++            }
++
++            // Steady-state conservation: net table-capacity consumption of the measured window is
++            //   (fresh allocations + reuses) - releases,
++            // i.e. allocations the window performed minus slots its sweeps returned. This bound is
++            // what actually forbids the linear leak: the identity is independent of how large the
++            // free set happened to be, so a sweep that misses even one slot per cycle consumes at
++            // least one NET slot per cycle no matter the buffering, totaling >= MeasuredCycles.
++            // A correct sweep returns every collectible-owned slot, leaving only the bounded
++            // one-time default-ALC compilations (live by design, already drained by warm-up), so
++            // strictly-below-one-per-cycle is the tightest sound bound this allocator supports.
++            int freshDelta = TraceStat(StatFreshAllocated) - freshAtStart;
++            int reusedDelta = TraceStat(StatTotalReused) - reusedAtStart;
++            int freedDelta = TraceStat(StatTotalFreed) - freedAtStart;
++            int netConsumption = (freshDelta + reusedDelta) - freedDelta;
++            Assert.True(netConsumption < MeasuredCycles,
++                $"steady-state forced-unload cycles must not consume table capacity linearly: net consumption " +
++                $"(fresh {freshDelta} + reused {reusedDelta} - freed {freedDelta}) = {netConsumption} over " +
++                $"{MeasuredCycles} cycles (>= {MeasuredCycles} means at least one slot leaks every cycle; " +
++                $"free={TraceStat(StatFreeCount)}).");
 +
 +            // The reclamation must not have disturbed the ALC teardown itself: the forced-down
 +            // contexts stay reclaimable.
@@ -398,6 +461,7 @@ index 0000000..e9abe36
 +            Assert.Equal(-1, TraceStat(StatFreeCount));
 +            Assert.Equal(-1, TraceStat(StatTotalFreed));
 +            Assert.Equal(-1, TraceStat(StatTotalReused));
++            Assert.Equal(-1, TraceStat(StatNoTraceSweeps));
 +            GC.KeepAlive(context);
 +        }
 +
@@ -411,8 +475,12 @@ index 0000000..e9abe36
 +        /// trace-less method would have handed that live slot back to the allocator, after which the
 +        /// still-live call site would dispatch to whichever trace was installed next.
 +        /// <para>
-+        /// Unloading an ALC whose methods were never driven hot is exactly that case: every method
-+        /// takes the sentinel path and none owns a trace. Nothing may be released.
++        /// Unloading an ALC whose invoked method owns no trace is exactly that case: its
++        /// InterpMethod is swept via the sentinel path and nothing may be released. The test is
++        /// deliberately non-vacuous on both sides: the no-trace sweep counter (kind 4) must move,
++        /// proving an InterpMethod from the collectible memory manager really reached the sentinel
++        /// branch — merely loading the assembly (e.g. GetTypes) creates no InterpMethod and would
++        /// leave the sweep with nothing to do.
 +        /// </para>
 +        /// </summary>
 +        [Fact]
@@ -427,40 +495,60 @@ index 0000000..e9abe36
 +            {
 +                // Feature dark — the stats are unavailable and nothing is reclaimable anyway.
 +                Assert.Equal(-1, TraceStat(StatTotalFreed));
++                Assert.Equal(-1, TraceStat(StatNoTraceSweeps));
 +                return;
 +            }
 +
 +            int freedBefore = TraceStat(StatTotalFreed);
++            int sentinelSweepsBefore = TraceStat(StatNoTraceSweeps);
 +            Assert.True(freedBefore >= 0, $"total-freed must be available with the opt-in active (got {freedBefore})");
++            Assert.True(sentinelSweepsBefore >= 0, $"no-trace sweep count must be available with the opt-in active (got {sentinelSweepsBefore})");
 +
 +            // Asserts Completed internally, so reaching the next line proves the sweep really ran
 +            // over the unloaded ALC's methods rather than the force having been refused.
 +            LoadUnloadAndForceWithoutHotLoop();
 +
++            // Non-vacuity: at least one swept method (the invoked no-trace bait's InterpMethod at
++            // minimum) took the need_extra_free sentinel branch during the forced unload.
++            Assert.True(TraceStat(StatNoTraceSweeps) > sentinelSweepsBefore,
++                $"the forced unload must sweep the invoked trace-less method through the no-trace sentinel path " +
++                $"(noTraceSweeps before={sentinelSweepsBefore} after={TraceStat(StatNoTraceSweeps)}). " +
++                "If the counter did not move, the collectible InterpMethod never reached the sweep and this test proved nothing.");
++
++            // The regression itself: a sentinel sweep must not release anyone's slot — with the
++            // old 0 sentinel it would have released the live trace-0 slot of a default-ALC method.
 +            Assert.Equal(freedBefore, TraceStat(StatTotalFreed));
 +        }
 +
-+        // Loads the collectible assembly and unloads it WITHOUT driving the trace bait, so no trace
-+        // is ever compiled inside it and every swept method takes the no-trace sentinel path.
++        // Loads the collectible assembly and unloads it WITHOUT driving the trace bait hot, so no
++        // trace is ever compiled inside it and its swept InterpMethod takes the no-trace sentinel
++        // path.
 +        [MethodImpl(MethodImplOptions.NoInlining)]
 +        private static void LoadUnloadAndForceWithoutHotLoop()
 +        {
 +            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
-+            TouchWithoutCompilingATrace(context);
++            InvokeWithoutCompilingATrace(context);
 +            context.Unload();
 +            Assert.Equal(Completed, ForceUntilCompleted(context, 10));
 +        }
 +
-+        // One cheap reflection touch so the assembly is really loaded and its methods really enter
-+        // the interp code hash — but far below the jiterpreter hit-count threshold, so no trace is
-+        // compiled and the sweep has only trace-less methods to free.
++        // Invokes the deliberately jiterpreter-ineligible bait exactly once. The invocation forces
++        // mono_interp_get_imethod to create an InterpMethod in the collectible memory manager's
++        // interp_code_hash — which is what the unload sweep iterates — while the method's
++        // straight-line body guarantees the transform emitted no trace entry points for it, so the
++        // sweep must take the no-trace sentinel branch for it. (Merely loading types via
++        // reflection creates no InterpMethod and would leave this test vacuous.)
 +        [MethodImpl(MethodImplOptions.NoInlining)]
-+        private static void TouchWithoutCompilingATrace(AssemblyLoadContext context)
++        private static void InvokeWithoutCompilingATrace(AssemblyLoadContext context)
 +        {
 +            Assembly asm = context.LoadFromAssemblyName(new AssemblyName(TestAssembly));
 +            Type type = asm.GetType(TestClassName, throwOnError: true);
 +            Assert.NotNull(type);
-+            Assert.NotEmpty(asm.GetTypes());
++            MethodInfo bait = type.GetMethod("JiterpreterNoTraceBait", BindingFlags.Public | BindingFlags.Static);
++            Assert.NotNull(bait);
++
++            object result = bait.Invoke(null, new object[] { 41 });
++            Assert.Equal(42, Assert.IsType<int>(result));
 +        }
 +
 +        private static WeakReference LoadRunHotLoopUnloadAndForce()
@@ -518,7 +606,7 @@ index 0000000..e9abe36
 +    }
 +}
 diff --git a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs
-index 7d3bb5e..d8bc7f3 100644
+index 7d3bb5ebe..ede632a92 100644
 --- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs
 +++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs
 @@ -1,6 +1,7 @@
@@ -529,7 +617,7 @@ index 7d3bb5e..d8bc7f3 100644
  using System.Runtime.InteropServices;
  
  namespace System.Runtime.Loader.Tests
-@@ -35,6 +36,39 @@ namespace System.Runtime.Loader.Tests
+@@ -35,6 +36,51 @@ public static void TestDelegateMarshalling()
          public class COMClass
          {
          }
@@ -555,6 +643,18 @@ index 7d3bb5e..d8bc7f3 100644
 +            return acc;
 +        }
 +
++        // Deliberately jiterpreter-INELIGIBLE counterpart of JiterpreterHotLoop, for the
++        // no-trace sentinel-sweep regression test. Straight-line int arithmetic with no calls
++        // and no backward branches: its estimated trace value stays far below the
++        // jiterpreter-minimum-trace-value heuristic (default 18), so the interpreter transform
++        // emits NO trace entry points for it. Invoking it once therefore creates an
++        // InterpMethod in this collectible assembly's memory manager that owns no trace —
++        // exactly the shape whose unload sweep must take the no-trace sentinel path.
++        public static int JiterpreterNoTraceBait(int value)
++        {
++            return value + 1;
++        }
++
 +        [MethodImpl(MethodImplOptions.NoInlining)]
 +        public static int JiterpreterHotBody(int a, int i)
 +        {
@@ -570,7 +670,7 @@ index 7d3bb5e..d8bc7f3 100644
  
      // Used to test LoaderAllocator used for a generic type instance allocation
 diff --git a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
-index bbdad35..09a06f1 100644
+index bbdad35cc..09a06f1b3 100644
 --- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
 +++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
 @@ -32,6 +32,7 @@
@@ -582,10 +682,10 @@ index bbdad35..09a06f1 100644
      <EmbeddedResource Include="MainStrings*.resx" />
    </ItemGroup>
 diff --git a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
-index cc30e0c..8682a15 100644
+index cc30e0cdb..bf45b0438 100644
 --- a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
 +++ b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
-@@ -37,6 +37,7 @@ namespace System.Runtime.Loader
+@@ -37,6 +37,7 @@ internal IntPtr NativeALC
          [DynamicDependency(nameof(_nativeAssemblyLoadContext))]
          [DynamicDependency(nameof(ForceNativeUnload))] // trim-root: hosts invoke this bridge via reflection
          [DynamicDependency(nameof(GetScoutRetirementStats))] // trim-root: diagnostics bridge, invoked via reflection
@@ -593,7 +693,7 @@ index cc30e0c..8682a15 100644
          private IntPtr InitializeAssemblyLoadContext(IntPtr thisHandlePtr, bool representsTPALoadContext, bool isCollectible)
          {
              if (isCollectible)
-@@ -78,6 +79,21 @@ namespace System.Runtime.Loader
+@@ -78,6 +79,22 @@ private static void KeepLoaderAllocator()
          // unconditional (not part of the DISABLE_THREADS-gated forced teardown).
          internal static int GetScoutRetirementStats(int kind) => InternalGetScoutRetirementStats(kind);
  
@@ -602,9 +702,10 @@ index cc30e0c..8682a15 100644
 +
 +        // Diagnostic bridge for the jiterpreter function-table slot-reclamation lifecycle tests.
 +        // Mirrors mono_jiterp_get_table_stat (jiterpreter.c): `table` is a JITERPRETER_TABLE_*
-+        // value (0 = traces) and `kind` selects the statistic (0 = fresh slots allocated,
-+        // 1 = slots currently free, 2 = total slots ever released, 3 = total released slots ever
-+        // reused). Returns -1 whenever slot reclamation is unavailable (non-browser runtime,
++        // value (0 = traces) and `kind` selects the statistic (0 = fresh slots successfully
++        // handed out, 1 = slots currently free, 2 = total slots ever released, 3 = total released
++        // slots ever reused, 4 = no-trace sentinel sweeps — all monotonic except 1).
++        // Returns -1 whenever slot reclamation is unavailable (non-browser runtime,
 +        // threads-enabled build) or the MONO_WASM_ENABLE_ALC_UNLOAD opt-in is absent, so this
 +        // surface is as dark by default as the feature it observes.
 +        internal static int GetJiterpreterTableStat(int table, int kind)
@@ -616,7 +717,7 @@ index cc30e0c..8682a15 100644
          // return codes of ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload
          // in the native assembly-load-context.c.
 diff --git a/src/mono/browser/runtime/cwraps.ts b/src/mono/browser/runtime/cwraps.ts
-index e693c52..c02fbd7 100644
+index e693c5223..c02fbd777 100644
 --- a/src/mono/browser/runtime/cwraps.ts
 +++ b/src/mono/browser/runtime/cwraps.ts
 @@ -120,6 +120,7 @@ const fn_signatures: SigLine[] = [
@@ -637,7 +738,7 @@ index e693c52..c02fbd7 100644
      mono_jiterp_get_counter(counter: number): number;
      mono_jiterp_modify_counter(counter: number, delta: number): number;
 diff --git a/src/mono/browser/runtime/jiterpreter.ts b/src/mono/browser/runtime/jiterpreter.ts
-index 6ba17a3..09ba3a4 100644
+index 6ba17a3ab..09ba3a418 100644
 --- a/src/mono/browser/runtime/jiterpreter.ts
 +++ b/src/mono/browser/runtime/jiterpreter.ts
 @@ -1088,10 +1088,38 @@ export function mono_wasm_free_method_data (
@@ -684,7 +785,7 @@ index 6ba17a3..09ba3a4 100644
      mono_jiterp_free_method_data_interp_entry(imethod);
      mono_jiterp_free_method_data_jit_call(method);
 diff --git a/src/mono/mono/metadata/assembly-load-context.c b/src/mono/mono/metadata/assembly-load-context.c
-index 382247f..206c1a6 100644
+index 382247fa9..206c1a653 100644
 --- a/src/mono/mono/metadata/assembly-load-context.c
 +++ b/src/mono/mono/metadata/assembly-load-context.c
 @@ -617,6 +617,37 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
@@ -726,7 +827,7 @@ index 382247f..206c1a6 100644
  ves_icall_System_Runtime_Loader_AssemblyLoadContext_GetLoadContextForAssembly (MonoReflectionAssemblyHandle assm_obj, MonoError *error)
  {
 diff --git a/src/mono/mono/metadata/icall-def.h b/src/mono/mono/metadata/icall-def.h
-index 4e1a934..e4ca6f1 100644
+index 4e1a93423..e4ca6f1d6 100644
 --- a/src/mono/mono/metadata/icall-def.h
 +++ b/src/mono/mono/metadata/icall-def.h
 @@ -473,6 +473,7 @@ NOHANDLES(ICALL(X86BASE_1, "__cpuidex", ves_icall_System_Runtime_Intrinsics_X86_
@@ -738,7 +839,7 @@ index 4e1a934..e4ca6f1 100644
  HANDLES(ALC_8, "InternalGetScoutRetirementStats", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementStats, int, 1, (gint32))
  HANDLES(ALC_2, "InternalInitializeNativeALC", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalInitializeNativeALC, gpointer, 4, (gpointer, const_char_ptr, MonoBoolean, MonoBoolean))
 diff --git a/src/mono/mono/mini/interp/interp.c b/src/mono/mono/mini/interp/interp.c
-index a47d812..4db8b85 100644
+index a47d81246..4db8b85bd 100644
 --- a/src/mono/mono/mini/interp/interp.c
 +++ b/src/mono/mono/mini/interp/interp.c
 @@ -3743,15 +3743,17 @@ free_imethod_jiterp_cb (gpointer value, gpointer user_data)
@@ -769,10 +870,30 @@ index a47d812..4db8b85 100644
  void
  mono_interp_free_mem_manager_jiterp (MonoJitMemoryManager *jit_mm)
 diff --git a/src/mono/mono/mini/interp/jiterpreter.c b/src/mono/mono/mini/interp/jiterpreter.c
-index 887038c..86cbdc9 100644
+index 887038ca4..6e26e4499 100644
 --- a/src/mono/mono/mini/interp/jiterpreter.c
 +++ b/src/mono/mono/mini/interp/jiterpreter.c
-@@ -988,7 +988,10 @@ mono_jiterp_free_method_data (MonoMethod *method, InterpMethod *imethod)
+@@ -946,6 +946,19 @@ mono_interp_tier_prepare_jiterpreter_fast (
+ 	}
+ }
+ 
++#ifdef DISABLE_THREADS
++/*
++ * Monotonic count of no-trace sentinel sweeps: how many times the need_extra_free branch
++ * below passed -1 to mono_wasm_free_method_data because the method being freed contained
++ * no trace entry points. Exposed as kind 4 of mono_jiterp_get_table_stat so the lifecycle
++ * tests can prove the sentinel path actually executed for a swept method (an empty
++ * interp_code_hash would otherwise make the "no slot was released" assertion vacuous).
++ * Part of the DISABLE_THREADS-gated reclamation diagnostics; see the state block above
++ * mono_jiterp_free_table_entry further down.
++ */
++static gint32 jiterp_no_trace_sweep_count = 0;
++#endif
++
+ void
+ mono_jiterp_free_method_data (MonoMethod *method, InterpMethod *imethod)
+ {
+@@ -988,7 +1001,13 @@ mono_jiterp_free_method_data (MonoMethod *method, InterpMethod *imethod)
  	if (need_extra_free) {
  		// HACK: Perform a single free operation to clear out any stuff from the jit queues
  		// This will happen if we didn't encounter any jiterpreter traces in the method
@@ -780,11 +901,14 @@ index 887038c..86cbdc9 100644
 +		// Pass -1, NOT 0: trace indexes are allocated from zero (trace_count++), so 0 is a
 +		// real trace that very likely belongs to a live method in another (default) ALC.
 +		// The JS side treats a negative index as "no trace" and skips all per-trace work.
++#ifdef DISABLE_THREADS
++		jiterp_no_trace_sweep_count++;
++#endif
 +		mono_wasm_free_method_data (method, imethod, -1);
  	}
  }
  
-@@ -1476,6 +1479,46 @@ mono_jiterp_is_imethod_var_address_taken (InterpMethod *imethod, int offset) {
+@@ -1476,6 +1495,55 @@ mono_jiterp_is_imethod_var_address_taken (InterpMethod *imethod, int offset) {
  JiterpreterTableInfo tables[JITERPRETER_TABLE_LAST + 1] = { 0 };
  int mono_jiterp_first_trace_fn_ptr = 0;
  
@@ -810,6 +934,15 @@ index 887038c..86cbdc9 100644
 +static gint32 table_free_counts [JITERPRETER_TABLE_LAST + 1] = { 0 };
 +static gint32 table_total_freed [JITERPRETER_TABLE_LAST + 1] = { 0 };
 +static gint32 table_total_reused [JITERPRETER_TABLE_LAST + 1] = { 0 };
++/*
++ * Successful fresh allocations only. This is a dedicated counter rather than being derived
++ * from next_index because the allocator advances next_index BEFORE the bounds check, so
++ * (next_index - first_index) counts failed allocations too: the first exhaustion already
++ * reads capacity + 1, and because an accepted release re-enables trace generation, later
++ * refill/exhaustion episodes keep advancing next_index without handing out a slot. It also
++ * cannot go negative on a table that has first_index set but no allocations yet.
++ */
++static gint32 table_fresh_allocated [JITERPRETER_TABLE_LAST + 1] = { 0 };
 +
 +static gboolean
 +jiterp_table_reclamation_enabled (void) {
@@ -831,7 +964,7 @@ index 887038c..86cbdc9 100644
  static void
  atomically_set_value_once (gint32 *address, gint32 value) {
  #ifdef DISABLE_THREADS
-@@ -1530,6 +1573,17 @@ mono_jiterp_allocate_table_entry (int type) {
+@@ -1530,6 +1598,17 @@ mono_jiterp_allocate_table_entry (int type) {
  #ifdef DISABLE_THREADS
  	if (table->next_index == 0)
  		table->next_index = table->first_index;
@@ -849,7 +982,15 @@ index 887038c..86cbdc9 100644
  	int index = table->next_index++;
  #else
  	gint32 expected = 0;
-@@ -1546,6 +1600,88 @@ mono_jiterp_allocate_table_entry (int type) {
+@@ -1543,9 +1622,101 @@ mono_jiterp_allocate_table_entry (int type) {
+ 			g_printf ("MONO_WASM: Jiterpreter table %d is out of space (%d entries allocated)\n", type, index - table->first_index + 1);
+ 		return 0;
+ 	}
++#ifdef DISABLE_THREADS
++	// Count only slots actually handed out: next_index above advances even when the bounds
++	//  check then fails, so it cannot serve as a successful-allocation diagnostic.
++	table_fresh_allocated [type]++;
++#endif
  	return index;
  }
  
@@ -903,10 +1044,14 @@ index 887038c..86cbdc9 100644
 + * reclamation feature is unavailable (threads-enabled build) or not opted into, so the
 + * stats surface stays as dark as the feature itself. The kind values MUST stay in sync
 + * with the managed test consumer:
-+ *   0 = fresh slots handed out by advancing next_index (excludes reused slots)
++ *   0 = fresh slots successfully handed out (monotonic; a dedicated counter, NOT derived
++ *       from next_index, so failed allocations are excluded and it is never negative)
 + *   1 = slots currently sitting on the free set
 + *   2 = total slots ever released (monotonic)
 + *   3 = total released slots ever reused by the allocator (monotonic)
++ *   4 = no-trace sentinel sweeps (monotonic; how often mono_jiterp_free_method_data freed
++ *       a method with no trace entry points — table-agnostic, but still requires a valid
++ *       table so the invalid-argument probes stay uniform; query it via the trace table)
 + */
 +gint32
 +mono_jiterp_get_table_stat (int type, int kind) {
@@ -919,16 +1064,17 @@ index 887038c..86cbdc9 100644
 +		return -1;
 +	if ((type < 0) || (type > JITERPRETER_TABLE_LAST))
 +		return -1;
-+	JiterpreterTableInfo *table = &tables[type];
 +	switch (kind) {
 +		case 0:
-+			return (table->first_index > 0) ? (table->next_index - table->first_index) : 0;
++			return table_fresh_allocated [type];
 +		case 1:
 +			return table_free_counts [type];
 +		case 2:
 +			return table_total_freed [type];
 +		case 3:
 +			return table_total_reused [type];
++		case 4:
++			return jiterp_no_trace_sweep_count;
 +		default:
 +			return -1;
 +	}
@@ -938,3 +1084,6 @@ index 887038c..86cbdc9 100644
  int
  mono_jiterp_increment_counter (volatile int *counter) {
  #ifdef DISABLE_THREADS
+-- 
+2.53.0.vfs.0.0
+

--- a/patches/0012-reclaim-jiterpreter-table-slots-on-forced-alc-unload.patch
+++ b/patches/0012-reclaim-jiterpreter-table-slots-on-forced-alc-unload.patch
@@ -94,6 +94,17 @@ for default consumers.
 
 Fixes https://github.com/unoplatform/Uno.DotnetRuntime.WebAssembly/issues/166
 Refs dotnet/runtime#89980.
+
+ * No-trace sentinel: mono_jiterp_free_method_data calls
+ *   mono_wasm_free_method_data once with a sentinel index when a method has no
+ *   trace entry points, purely to drain the general JIT queues. That sentinel was
+ *   0 -- but trace indexes are allocated from zero, so 0 aliases a real trace that
+ *   typically belongs to a live default-ALC method. Upstream that only dropped the
+ *   wrong traceInfo entry; with slot reclamation it would also hand a LIVE table
+ *   slot back to the allocator, after which the still-live call site would dispatch
+ *   to whichever trace was installed next. The sentinel is now -1 and every
+ *   traceInfo/slot operation is guarded on traceIndex >= 0.
+
 ---
  .../tests/ForcedNativeUnloadTests.cs          |  15 +-
  .../tests/JiterpreterTableReclamationTests.cs | 304 ++++++++++++++++++
@@ -110,10 +121,10 @@ Refs dotnet/runtime#89980.
  create mode 100644 src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs
 
 diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
-index 6eae223ba..89807864e 100644
+index efaaffd..89b4c64 100644
 --- a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 +++ b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
-@@ -167,16 +167,11 @@ private static int ForceUntilCompleted(AssemblyLoadContext context, int maxAttem
+@@ -174,16 +174,11 @@ namespace System.Runtime.Loader.Tests
              return outcome;
          }
  
@@ -137,10 +148,10 @@ index 6eae223ba..89807864e 100644
          {
 diff --git a/src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs b/src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs
 new file mode 100644
-index 000000000..315569387
+index 0000000..e9abe36
 --- /dev/null
 +++ b/src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs
-@@ -0,0 +1,304 @@
+@@ -0,0 +1,365 @@
 +// Licensed to the .NET Foundation under one or more agreements.
 +// The .NET Foundation licenses this file to you under the MIT license.
 +
@@ -391,6 +402,67 @@ index 000000000..315569387
 +        }
 +
 +        [MethodImpl(MethodImplOptions.NoInlining)]
++        /// <summary>
++        /// Regression for the no-trace sentinel. `mono_jiterp_free_method_data` calls
++        /// `mono_wasm_free_method_data` once with a sentinel index for a method that has NO trace
++        /// entry points, purely to drain the general JIT queues. That sentinel used to be `0` — but
++        /// trace indexes are allocated from zero, so `0` aliases a real trace that typically belongs
++        /// to a live method in the default ALC. With slot reclamation in place, sweeping any
++        /// trace-less method would have handed that live slot back to the allocator, after which the
++        /// still-live call site would dispatch to whichever trace was installed next.
++        /// <para>
++        /// Unloading an ALC whose methods were never driven hot is exactly that case: every method
++        /// takes the sentinel path and none owns a trace. Nothing may be released.
++        /// </para>
++        /// </summary>
++        [Fact]
++        public void ForcedUnload_WithoutAnyCompiledTrace_ReleasesNoSlots()
++        {
++            if (BridgeMissing())
++            {
++                return;
++            }
++
++            if (!FlagEnabled || PlatformDetection.IsThreadingSupported)
++            {
++                // Feature dark — the stats are unavailable and nothing is reclaimable anyway.
++                Assert.Equal(-1, TraceStat(StatTotalFreed));
++                return;
++            }
++
++            int freedBefore = TraceStat(StatTotalFreed);
++            Assert.True(freedBefore >= 0, $"total-freed must be available with the opt-in active (got {freedBefore})");
++
++            // Asserts Completed internally, so reaching the next line proves the sweep really ran
++            // over the unloaded ALC's methods rather than the force having been refused.
++            LoadUnloadAndForceWithoutHotLoop();
++
++            Assert.Equal(freedBefore, TraceStat(StatTotalFreed));
++        }
++
++        // Loads the collectible assembly and unloads it WITHOUT driving the trace bait, so no trace
++        // is ever compiled inside it and every swept method takes the no-trace sentinel path.
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static void LoadUnloadAndForceWithoutHotLoop()
++        {
++            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
++            TouchWithoutCompilingATrace(context);
++            context.Unload();
++            Assert.Equal(Completed, ForceUntilCompleted(context, 10));
++        }
++
++        // One cheap reflection touch so the assembly is really loaded and its methods really enter
++        // the interp code hash — but far below the jiterpreter hit-count threshold, so no trace is
++        // compiled and the sweep has only trace-less methods to free.
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static void TouchWithoutCompilingATrace(AssemblyLoadContext context)
++        {
++            Assembly asm = context.LoadFromAssemblyName(new AssemblyName(TestAssembly));
++            Type type = asm.GetType(TestClassName, throwOnError: true);
++            Assert.NotNull(type);
++            Assert.NotEmpty(asm.GetTypes());
++        }
++
 +        private static WeakReference LoadRunHotLoopUnloadAndForce()
 +        {
 +            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
@@ -446,7 +518,7 @@ index 000000000..315569387
 +    }
 +}
 diff --git a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs
-index 5cad40171..300d21636 100644
+index 7d3bb5e..d8bc7f3 100644
 --- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs
 +++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs
 @@ -1,6 +1,7 @@
@@ -457,7 +529,7 @@ index 5cad40171..300d21636 100644
  using System.Runtime.InteropServices;
  
  namespace System.Runtime.Loader.Tests
-@@ -35,6 +36,39 @@ public static void TestDelegateMarshalling()
+@@ -35,6 +36,39 @@ namespace System.Runtime.Loader.Tests
          public class COMClass
          {
          }
@@ -498,7 +570,7 @@ index 5cad40171..300d21636 100644
  
      // Used to test LoaderAllocator used for a generic type instance allocation
 diff --git a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
-index bbdad35cc..09a06f1b3 100644
+index bbdad35..09a06f1 100644
 --- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
 +++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
 @@ -32,6 +32,7 @@
@@ -510,10 +582,10 @@ index bbdad35cc..09a06f1b3 100644
      <EmbeddedResource Include="MainStrings*.resx" />
    </ItemGroup>
 diff --git a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
-index cc30e0cdb..8682a1521 100644
+index cc30e0c..8682a15 100644
 --- a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
 +++ b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
-@@ -37,6 +37,7 @@ internal IntPtr NativeALC
+@@ -37,6 +37,7 @@ namespace System.Runtime.Loader
          [DynamicDependency(nameof(_nativeAssemblyLoadContext))]
          [DynamicDependency(nameof(ForceNativeUnload))] // trim-root: hosts invoke this bridge via reflection
          [DynamicDependency(nameof(GetScoutRetirementStats))] // trim-root: diagnostics bridge, invoked via reflection
@@ -521,7 +593,7 @@ index cc30e0cdb..8682a1521 100644
          private IntPtr InitializeAssemblyLoadContext(IntPtr thisHandlePtr, bool representsTPALoadContext, bool isCollectible)
          {
              if (isCollectible)
-@@ -78,6 +79,21 @@ private static void KeepLoaderAllocator()
+@@ -78,6 +79,21 @@ namespace System.Runtime.Loader
          // unconditional (not part of the DISABLE_THREADS-gated forced teardown).
          internal static int GetScoutRetirementStats(int kind) => InternalGetScoutRetirementStats(kind);
  
@@ -544,7 +616,7 @@ index cc30e0cdb..8682a1521 100644
          // return codes of ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload
          // in the native assembly-load-context.c.
 diff --git a/src/mono/browser/runtime/cwraps.ts b/src/mono/browser/runtime/cwraps.ts
-index e693c5223..c02fbd777 100644
+index e693c52..c02fbd7 100644
 --- a/src/mono/browser/runtime/cwraps.ts
 +++ b/src/mono/browser/runtime/cwraps.ts
 @@ -120,6 +120,7 @@ const fn_signatures: SigLine[] = [
@@ -565,40 +637,54 @@ index e693c5223..c02fbd777 100644
      mono_jiterp_get_counter(counter: number): number;
      mono_jiterp_modify_counter(counter: number, delta: number): number;
 diff --git a/src/mono/browser/runtime/jiterpreter.ts b/src/mono/browser/runtime/jiterpreter.ts
-index 6ba17a3ab..5e778f857 100644
+index 6ba17a3..09ba3a4 100644
 --- a/src/mono/browser/runtime/jiterpreter.ts
 +++ b/src/mono/browser/runtime/jiterpreter.ts
-@@ -1088,8 +1088,26 @@ export function mono_wasm_free_method_data (
+@@ -1088,10 +1088,38 @@ export function mono_wasm_free_method_data (
          mono_wasm_profiler_free_method(method);
      }
  
 -    // TODO: Uninstall the trace function pointer from the function pointer table,
 -    //  so that the compiled trace module can be freed by the browser eventually
-+    // Uninstall the compiled trace function from the function pointer table and recycle
-+    //  its slot, so repeated assembly-load-context unload cycles do not permanently
-+    //  consume table capacity (and so the engine can eventually collect the trace module).
-+    // mono_jiterp_free_table_entry only accepts the release when the runtime opted into
-+    //  forced ALC unload (MONO_WASM_ENABLE_ALC_UNLOAD on a single-threaded build) and the
-+    //  slot is a real, not-already-released allocation, so default configurations keep
-+    //  the upstream monotonic allocator behavior unchanged.
-+    const info = traceInfo[traceIndex];
-+    if (info && info.fnPtr) {
-+        if (cwraps.mono_jiterp_free_table_entry(JiterpreterTable.Trace, info.fnPtr) > 0) {
-+            // Repoint the slot at the safe placeholder (the same fill value used when the
-+            //  table was created), so a stale indirect call through it bails out to the
-+            //  interpreter instead of invoking a trace whose method has been freed.
-+            getWasmFunctionTable().set(info.fnPtr, getRawCwrap("mono_jiterp_placeholder_trace"));
-+            // Capacity is available again, so re-enable trace generation if the table had
-+            //  filled up. (Traces already tiered to NOT_JITTED/nop stay that way; only
-+            //  newly-created trace entry points benefit.)
-+            traceTableIsFull = false;
+-    // Release the trace info object, if present
+-    delete traceInfo[traceIndex];
++    // A negative traceIndex means "this method has no trace entry points" — the native side
++    //  still calls once, purely to drain the general JIT queues (see the need_extra_free HACK in
++    //  mono_jiterp_free_method_data). It is NOT an index into traceInfo. Guarding on it matters:
++    //  trace indexes are allocated from zero, so the old 0 sentinel aliased a real trace that
++    //  typically belongs to a live default-ALC method. Treating it as owned by the method being
++    //  freed would delete that trace's info and — with slot reclamation below — hand its live
++    //  table slot back to the allocator, after which the still-live call site would dispatch to
++    //  whichever trace was installed next.
++    if (traceIndex >= 0) {
++        // Uninstall the compiled trace function from the function pointer table and recycle
++        //  its slot, so repeated assembly-load-context unload cycles do not permanently
++        //  consume table capacity (and so the engine can eventually collect the trace module).
++        // mono_jiterp_free_table_entry only accepts the release when the runtime opted into
++        //  forced ALC unload (MONO_WASM_ENABLE_ALC_UNLOAD on a single-threaded build) and the
++        //  slot is a real, not-already-released allocation, so default configurations keep
++        //  the upstream monotonic allocator behavior unchanged.
++        const info = traceInfo[traceIndex];
++        if (info && info.fnPtr) {
++            if (cwraps.mono_jiterp_free_table_entry(JiterpreterTable.Trace, info.fnPtr) > 0) {
++                // Repoint the slot at the safe placeholder (the same fill value used when the
++                //  table was created), so a stale indirect call through it bails out to the
++                //  interpreter instead of invoking a trace whose method has been freed.
++                getWasmFunctionTable().set(info.fnPtr, getRawCwrap("mono_jiterp_placeholder_trace"));
++                // Capacity is available again, so re-enable trace generation if the table had
++                //  filled up. (Traces already tiered to NOT_JITTED/nop stay that way; only
++                //  newly-created trace entry points benefit.)
++                traceTableIsFull = false;
++            }
 +        }
++        // Release the trace info object, if present
++        delete traceInfo[traceIndex];
 +    }
-     // Release the trace info object, if present
-     delete traceInfo[traceIndex];
      // Remove any AOT data and queue entries associated with the method
+     mono_jiterp_free_method_data_interp_entry(imethod);
+     mono_jiterp_free_method_data_jit_call(method);
 diff --git a/src/mono/mono/metadata/assembly-load-context.c b/src/mono/mono/metadata/assembly-load-context.c
-index 382247fa9..206c1a653 100644
+index 382247f..206c1a6 100644
 --- a/src/mono/mono/metadata/assembly-load-context.c
 +++ b/src/mono/mono/metadata/assembly-load-context.c
 @@ -617,6 +617,37 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
@@ -640,7 +726,7 @@ index 382247fa9..206c1a653 100644
  ves_icall_System_Runtime_Loader_AssemblyLoadContext_GetLoadContextForAssembly (MonoReflectionAssemblyHandle assm_obj, MonoError *error)
  {
 diff --git a/src/mono/mono/metadata/icall-def.h b/src/mono/mono/metadata/icall-def.h
-index 4e1a93423..e4ca6f1d6 100644
+index 4e1a934..e4ca6f1 100644
 --- a/src/mono/mono/metadata/icall-def.h
 +++ b/src/mono/mono/metadata/icall-def.h
 @@ -473,6 +473,7 @@ NOHANDLES(ICALL(X86BASE_1, "__cpuidex", ves_icall_System_Runtime_Intrinsics_X86_
@@ -652,7 +738,7 @@ index 4e1a93423..e4ca6f1d6 100644
  HANDLES(ALC_8, "InternalGetScoutRetirementStats", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementStats, int, 1, (gint32))
  HANDLES(ALC_2, "InternalInitializeNativeALC", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalInitializeNativeALC, gpointer, 4, (gpointer, const_char_ptr, MonoBoolean, MonoBoolean))
 diff --git a/src/mono/mono/mini/interp/interp.c b/src/mono/mono/mini/interp/interp.c
-index a47d81246..4db8b85bd 100644
+index a47d812..4db8b85 100644
 --- a/src/mono/mono/mini/interp/interp.c
 +++ b/src/mono/mono/mini/interp/interp.c
 @@ -3743,15 +3743,17 @@ free_imethod_jiterp_cb (gpointer value, gpointer user_data)
@@ -683,10 +769,22 @@ index a47d81246..4db8b85bd 100644
  void
  mono_interp_free_mem_manager_jiterp (MonoJitMemoryManager *jit_mm)
 diff --git a/src/mono/mono/mini/interp/jiterpreter.c b/src/mono/mono/mini/interp/jiterpreter.c
-index 887038ca4..b323e8fcd 100644
+index 887038c..86cbdc9 100644
 --- a/src/mono/mono/mini/interp/jiterpreter.c
 +++ b/src/mono/mono/mini/interp/jiterpreter.c
-@@ -1476,6 +1476,46 @@ mono_jiterp_is_imethod_var_address_taken (InterpMethod *imethod, int offset) {
+@@ -988,7 +988,10 @@ mono_jiterp_free_method_data (MonoMethod *method, InterpMethod *imethod)
+ 	if (need_extra_free) {
+ 		// HACK: Perform a single free operation to clear out any stuff from the jit queues
+ 		// This will happen if we didn't encounter any jiterpreter traces in the method
+-		mono_wasm_free_method_data (method, imethod, 0);
++		// Pass -1, NOT 0: trace indexes are allocated from zero (trace_count++), so 0 is a
++		// real trace that very likely belongs to a live method in another (default) ALC.
++		// The JS side treats a negative index as "no trace" and skips all per-trace work.
++		mono_wasm_free_method_data (method, imethod, -1);
+ 	}
+ }
+ 
+@@ -1476,6 +1479,46 @@ mono_jiterp_is_imethod_var_address_taken (InterpMethod *imethod, int offset) {
  JiterpreterTableInfo tables[JITERPRETER_TABLE_LAST + 1] = { 0 };
  int mono_jiterp_first_trace_fn_ptr = 0;
  
@@ -733,7 +831,7 @@ index 887038ca4..b323e8fcd 100644
  static void
  atomically_set_value_once (gint32 *address, gint32 value) {
  #ifdef DISABLE_THREADS
-@@ -1530,6 +1570,17 @@ mono_jiterp_allocate_table_entry (int type) {
+@@ -1530,6 +1573,17 @@ mono_jiterp_allocate_table_entry (int type) {
  #ifdef DISABLE_THREADS
  	if (table->next_index == 0)
  		table->next_index = table->first_index;
@@ -751,7 +849,7 @@ index 887038ca4..b323e8fcd 100644
  	int index = table->next_index++;
  #else
  	gint32 expected = 0;
-@@ -1546,6 +1597,88 @@ mono_jiterp_allocate_table_entry (int type) {
+@@ -1546,6 +1600,88 @@ mono_jiterp_allocate_table_entry (int type) {
  	return index;
  }
  
@@ -840,6 +938,3 @@ index 887038ca4..b323e8fcd 100644
  int
  mono_jiterp_increment_counter (volatile int *counter) {
  #ifdef DISABLE_THREADS
--- 
-2.53.0.vfs.0.0
-

--- a/patches/0012-reclaim-jiterpreter-table-slots-on-forced-alc-unload.patch
+++ b/patches/0012-reclaim-jiterpreter-table-slots-on-forced-alc-unload.patch
@@ -1,0 +1,845 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nick Randolph <noreply@platform.uno>
+Date: Wed, 5 Aug 2026 00:00:00 +0000
+Subject: [PATCH] feat: reclaim jiterpreter WASM function-table slots on forced
+ ALC unload
+
+A downstream host loading previewed apps into collectible
+AssemblyLoadContexts reclaims their managed/native heap through the
+opt-in forced native unload (MONO_WASM_ENABLE_ALC_UNLOAD, patch 0009).
+One residual remained: compiled jiterpreter trace functions stayed
+installed in the WASM indirect function table, and the table allocator
+(mono_jiterp_allocate_table_entry) only ever advances next_index --
+slots were never released or reused (upstream scoped table-entry reuse
+out in dotnet/runtime#89980). Repeated load/unload cycles therefore
+permanently consumed trace-table capacity; on exhaustion new traces
+stopped being installed and newly-hot paths stayed on the interpreter
+(performance-only degradation, but unbounded in a long-lived worker).
+
+This change makes the existing per-method unload sweep release and
+reuse those slots. It is dark by default and hard-gated exactly like
+the feature it serves: every new native/JS behavior requires the
+MONO_WASM_ENABLE_ALC_UNLOAD opt-in AND the single-threaded browser
+build (DISABLE_THREADS) -- on a threads-enabled build uninstalling a
+table entry would race concurrent indirect calls through it, so there
+every release is refused and the allocator is byte-for-byte the
+upstream monotonic one.
+
+  * Slot ownership derives from the EXISTING sweep, not a new
+    allocation-side structure: the TypeScript runtime already records
+    each compiled trace's installed slot (traceInfo[traceIndex].fnPtr),
+    and mono_wasm_free_method_data is already invoked once per trace
+    entry point of every method being freed -- by the patch-0009
+    memory-manager sweep (mono_interp_free_mem_manager_jiterp ->
+    mono_jiterp_free_method_data) on forced unload, and by
+    interp_free_method for dynamic methods. That callback now offers
+    the recorded slot back to the runtime.
+  * New EMSCRIPTEN_KEEPALIVE mono_jiterp_free_table_entry(type, index)
+    (jiterpreter.c, crossing the boundary via cwraps like the existing
+    mono_jiterp_allocate_table_entry): validates that the index is a
+    real allocation of that table (in [first_index, last_index] and
+    below next_index -- which also rejects the TRAINING/NOT_JITTED
+    sentinels 0/1) and pushes it onto a per-table free bitset. A
+    double release is structurally impossible: the second release sees
+    the bit already set and is refused (returns 0), mirroring the
+    idempotence discipline of the 0009 free path that drives it. The
+    JS caller only uninstalls the entry when the release was accepted.
+  * Safe stub, not a dangling pointer: the accepted slot is repointed
+    at mono_jiterp_placeholder_trace -- the exact fill value
+    threads-enabled builds pre-populate trace tables with. A stale
+    indirect call through a released slot therefore returns the
+    ENTER-opcode displacement and execution continues in the
+    interpreter (the "not jitted yet" semantics the interpreter
+    already handles) instead of trapping or invoking a freed trace.
+    This is defense-in-depth: patch 0009's whole-set quiescence gate
+    already guarantees no frame of the unloaded ALC is live when the
+    sweep runs, so no live call site can reference the slot.
+  * Reuse before growth: mono_jiterp_allocate_table_entry (in its
+    DISABLE_THREADS branch only) consumes the free set before
+    advancing next_index, so steady-state load/unload cycles stop
+    consuming fresh capacity. The TS traceTableIsFull latch is cleared
+    when a release is accepted, so trace generation resumes even after
+    the table had filled up (traces already tiered to NOP/NOT_JITTED
+    stay that way; only new trace entry points benefit).
+  * Measured, deterministic lifecycle assertion: a new diagnostic
+    icall InternalGetJiterpreterTableStat (on the same internal type
+    as InternalForceNativeUnload; returns -1 whenever reclamation is
+    unavailable or not opted in, so the surface is as dark as the
+    feature) exposes per-table {fresh next_index allocations, current
+    free count, monotonic total-freed, monotonic total-reused}. New
+    JiterpreterTableReclamationTests drive repeated
+    load / hot-loop / unload / force cycles against a trace-bait
+    method added to the loader test assembly (pure int arithmetic,
+    well above the 5000 hit-count threshold; trace compilation is
+    synchronous at the threshold on the single-threaded runtime) and
+    assert (a) every cycle's forced unload increases total-freed and
+    (b) released slots are consumed by later allocations
+    (total-reused increases). The assertions intentionally use the
+    monotonic counters, NOT an exact next_index plateau: trace entry
+    points in default-ALC code (CoreLib/xunit) accumulate hit counts
+    across cycles and can compile at unpredictable moments, so a
+    plateau assertion would be flaky while the counter assertions
+    cannot be. With the flag off the tests assert the surface stays
+    dark (stats -1, force Rejected) -- the zero-change guarantee.
+
+SCOPE / still not covered: only JITERPRETER_TABLE_TRACE slots are ever
+released (the sweep only knows trace ownership). The jit-call and
+interp-entry wrapper tables are sized 1 in non-AOT browser builds and
+only populated under AOT, so they are not a leak vector for the
+interpreter-based unload scenario; their slots remain unreclaimed.
+Trace INDEXES (the trace_info segment space, MAX_TRACE_SEGMENTS *
+TRACE_SEGMENT_SIZE) also remain monotonic -- only WASM function-table
+slots are reused. Both are pre-existing bounded residuals, unchanged
+for default consumers.
+
+Fixes https://github.com/unoplatform/Uno.DotnetRuntime.WebAssembly/issues/166
+Refs dotnet/runtime#89980.
+---
+ .../tests/ForcedNativeUnloadTests.cs          |  15 +-
+ .../tests/JiterpreterTableReclamationTests.cs | 304 ++++++++++++++++++
+ .../TestClass.cs                              |  34 ++
+ .../tests/System.Runtime.Loader.Tests.csproj  |   1 +
+ .../Loader/AssemblyLoadContext.Mono.cs        |  16 +
+ src/mono/browser/runtime/cwraps.ts            |   3 +
+ src/mono/browser/runtime/jiterpreter.ts       |  22 +-
+ .../mono/metadata/assembly-load-context.c     |  31 ++
+ src/mono/mono/metadata/icall-def.h            |   1 +
+ src/mono/mono/mini/interp/interp.c            |  20 +-
+ src/mono/mono/mini/interp/jiterpreter.c       | 133 ++++++++
+ 11 files changed, 559 insertions(+), 21 deletions(-)
+ create mode 100644 src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs
+
+diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
+index 6eae223ba..89807864e 100644
+--- a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
++++ b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
+@@ -167,16 +167,11 @@ private static int ForceUntilCompleted(AssemblyLoadContext context, int maxAttem
+             return outcome;
+         }
+ 
+-        // Known residual, tracked and NOT measured here: on browser-wasm the jiterpreter's
+-        // compiled trace functions stay installed in the WASM indirect function table after a
+-        // forced unload, and table slots are never released or reused (the allocator's next_index
+-        // is monotonic), so repeated cycles consume bounded table capacity; on exhaustion new
+-        // traces stop being installed and execution stays in the interpreter (performance-only
+-        // degradation). The jiterpreter occupancy counters (mono_jiterp_get_counter) are
+-        // EMSCRIPTEN_KEEPALIVE exports consumed by the TypeScript runtime only — there is no
+-        // managed-visible counter this suite could read without inventing new API surface — so
+-        // this suite records the residual instead of measuring it. Tracked:
+-        // https://github.com/unoplatform/Uno.DotnetRuntime.WebAssembly/issues/166
++        // Jiterpreter WASM function-table slots (formerly a tracked residual of
++        // https://github.com/unoplatform/Uno.DotnetRuntime.WebAssembly/issues/166) are now
++        // reclaimed on forced unload when the opt-in flag is set, and that behavior is measured
++        // by JiterpreterTableReclamationTests via the GetJiterpreterTableStat diagnostic bridge.
++        // This suite keeps asserting the teardown protocol only.
+         [Fact]
+         public void RepeatedForcedUnload_DoesNotCrash_IsIdempotent_AndAlcIsCollectible()
+         {
+diff --git a/src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs b/src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs
+new file mode 100644
+index 000000000..315569387
+--- /dev/null
++++ b/src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs
+@@ -0,0 +1,304 @@
++// Licensed to the .NET Foundation under one or more agreements.
++// The .NET Foundation licenses this file to you under the MIT license.
++
++using System;
++using System.Reflection;
++using System.Runtime.CompilerServices;
++using Xunit;
++
++namespace System.Runtime.Loader.Tests
++{
++    /// <summary>
++    /// In-process lifecycle tests for jiterpreter WASM function-table slot reclamation on
++    /// host-triggered native unload of collectible AssemblyLoadContexts (opt-in via
++    /// MONO_WASM_ENABLE_ALC_UNLOAD). They complement ForcedNativeUnloadTests: that suite proves
++    /// the managed/native heap teardown protocol, this one proves the residual it documented —
++    /// compiled jiterpreter trace functions staying installed in the WASM indirect function
++    /// table forever — is fixed: a forced unload releases the trace-table slots owned by the
++    /// dying context's methods, and the allocator reuses released slots before consuming fresh
++    /// capacity.
++    ///
++    /// Measurement goes through the diagnostic bridge AssemblyLoadContext.GetJiterpreterTableStat
++    /// (table, kind), which surfaces per-table counters from the native allocator:
++    ///   kind 0 = fresh slots handed out by advancing next_index (excludes reused slots)
++    ///   kind 1 = slots currently sitting on the free set
++    ///   kind 2 = total slots ever released (monotonic)
++    ///   kind 3 = total released slots ever reused by the allocator (monotonic)
++    /// The bridge returns -1 whenever slot reclamation is unavailable (non-browser runtime,
++    /// threads-enabled build) or the opt-in flag is absent, so the surface is as dark by default
++    /// as the feature itself — which the tests assert too.
++    ///
++    /// Determinism: the assertions deliberately avoid an exact next_index plateau. Trace entry
++    /// points in default-ALC code (CoreLib, xunit) accumulate hit counts across cycles and can
++    /// cross the compile threshold at unpredictable moments, so next_index may legitimately
++    /// creep. Instead the tests assert the two facts that cannot be timing-dependent on the
++    /// single-threaded runtime (where trace compilation is synchronous at the hit threshold):
++    ///   * every forced-unload cycle of a context that provably compiled a trace increases the
++    ///     monotonic total-freed counter (the release happened), and
++    ///   * after slots have been released, a later allocation consumes one (the monotonic
++    ///     total-reused counter moves), because the allocator always prefers the free set.
++    /// </summary>
++    [Collection(nameof(DisableParallelization))]
++    public class JiterpreterTableReclamationTests
++    {
++        private const string TestAssembly = "System.Runtime.Loader.Test.Assembly";
++        private const string TestClassName = "System.Runtime.Loader.Tests.TestClass";
++
++        // JITERPRETER_TABLE_TRACE in jiterpreter.h / JiterpreterTable.Trace in the TS runtime.
++        private const int TraceTable = 0;
++
++        // Stat kinds; MUST match mono_jiterp_get_table_stat in jiterpreter.c.
++        private const int StatFreshAllocated = 0;
++        private const int StatFreeCount = 1;
++        private const int StatTotalFreed = 2;
++        private const int StatTotalReused = 3;
++
++        // Outcome codes; MUST match AssemblyLoadContext.ForceNativeUnloadResult.
++        private const int Completed = 0;
++        private const int Rejected = 2;
++
++        // The default jiterpreter-minimum-trace-hit-count is 5000; use a comfortable margin so
++        // the hot loop's trace entry points are guaranteed to cross the compile threshold.
++        private const int HotCalls = 12_000;
++
++        private static readonly MethodInfo s_forceNativeUnload = typeof(AssemblyLoadContext)
++            .GetMethod("ForceNativeUnload", BindingFlags.NonPublic | BindingFlags.Instance);
++
++        private static readonly MethodInfo s_getJiterpreterTableStat = typeof(AssemblyLoadContext)
++            .GetMethod("GetJiterpreterTableStat", BindingFlags.NonPublic | BindingFlags.Static);
++
++        private static bool FlagEnabled
++        {
++            get
++            {
++                string value = Environment.GetEnvironmentVariable("MONO_WASM_ENABLE_ALC_UNLOAD");
++                return value == "1" || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
++            }
++        }
++
++        // Set by CI to demand that the bridge members are actually present (see
++        // ForcedNativeUnloadTests.RequireBridge): a missing member is then a trim/rooting
++        // regression, not a legitimately unpatched runtime.
++        private static bool RequireBridge =>
++            Environment.GetEnvironmentVariable("MONO_WASM_ALC_UNLOAD_REQUIRE_BRIDGE") == "1";
++
++        private static bool BridgeMissing()
++        {
++            if (s_forceNativeUnload != null && s_getJiterpreterTableStat != null)
++            {
++                return false;
++            }
++
++            Assert.False(RequireBridge,
++                "AssemblyLoadContext.ForceNativeUnload / GetJiterpreterTableStat is missing: the bridge was trimmed away, or the patch is not applied (trim/rooting regression).");
++            return true;
++        }
++
++        private static int Force(AssemblyLoadContext context)
++        {
++            object result = s_forceNativeUnload.Invoke(context, null);
++            return Convert.ToInt32(result);
++        }
++
++        private static int Stat(int table, int kind)
++        {
++            object result = s_getJiterpreterTableStat.Invoke(null, new object[] { table, kind });
++            return Convert.ToInt32(result);
++        }
++
++        private static int TraceStat(int kind) => Stat(TraceTable, kind);
++
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static void GcQuiesce()
++        {
++            for (int i = 0; i < 3; i++)
++            {
++                GC.Collect();
++                GC.WaitForPendingFinalizers();
++            }
++        }
++
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static int ForceUntilCompleted(AssemblyLoadContext context, int maxAttempts)
++        {
++            int outcome = -1;
++            for (int i = 0; i < maxAttempts; i++)
++            {
++                GcQuiesce();
++                outcome = Force(context);
++                if (outcome == Completed)
++                {
++                    break;
++                }
++            }
++
++            return outcome;
++        }
++
++        [Fact]
++        public void JiterpreterTableStat_SurfaceMatchesOptIn()
++        {
++            if (BridgeMissing())
++            {
++                return;
++            }
++
++            // Invalid table/kind values are always refused, opted in or not.
++            Assert.Equal(-1, Stat(TraceTable, 99));
++            Assert.Equal(-1, Stat(99, StatFreshAllocated));
++            Assert.Equal(-1, Stat(-1, StatFreshAllocated));
++
++            if (!FlagEnabled || PlatformDetection.IsThreadingSupported)
++            {
++                // Feature dark: without the opt-in — or on a threads-enabled runtime, where slot
++                // reclamation is compiled out just like the forced unload it serves — every stat
++                // reports unavailable and nothing about the allocator is observable.
++                Assert.Equal(-1, TraceStat(StatFreshAllocated));
++                Assert.Equal(-1, TraceStat(StatFreeCount));
++                Assert.Equal(-1, TraceStat(StatTotalFreed));
++                Assert.Equal(-1, TraceStat(StatTotalReused));
++                return;
++            }
++
++            // Opted in on the single-threaded runtime: the stats must be live and coherent.
++            int fresh = TraceStat(StatFreshAllocated);
++            int free = TraceStat(StatFreeCount);
++            int totalFreed = TraceStat(StatTotalFreed);
++            int totalReused = TraceStat(StatTotalReused);
++
++            Assert.True(fresh >= 0, $"fresh allocation count must be available with the opt-in active (got {fresh})");
++            Assert.True(free >= 0, $"free count must be available with the opt-in active (got {free})");
++            Assert.True(totalFreed >= 0, $"total-freed must be available with the opt-in active (got {totalFreed})");
++            Assert.True(totalReused >= 0, $"total-reused must be available with the opt-in active (got {totalReused})");
++
++            // Only distinct previously-allocated slots can sit on the free set, and every reuse
++            // consumed a prior release.
++            Assert.True(free <= fresh, $"slots on the free set ({free}) cannot exceed distinct slots ever handed out fresh ({fresh})");
++            Assert.True(totalReused <= totalFreed, $"reuses ({totalReused}) cannot exceed releases ({totalFreed})");
++        }
++
++        [Fact]
++        public void ForcedUnload_ReclaimsJiterpreterTraceTableSlots()
++        {
++            if (BridgeMissing())
++            {
++                return;
++            }
++
++            if (!FlagEnabled || PlatformDetection.IsThreadingSupported)
++            {
++                // Feature dark (no opt-in, or threads-enabled runtime): the hot loop still runs,
++                // the force is Rejected as in ForcedNativeUnloadTests, and no reclamation state
++                // is observable — proving default consumers see zero change from this feature.
++                RunDarkModeCycle();
++                return;
++            }
++
++            const int Cycles = 3;
++            int reusedAtStart = TraceStat(StatTotalReused);
++            var refs = new WeakReference[Cycles];
++
++            for (int i = 0; i < Cycles; i++)
++            {
++                int freedBefore = TraceStat(StatTotalFreed);
++                refs[i] = LoadRunHotLoopUnloadAndForce();
++                int freedAfter = TraceStat(StatTotalFreed);
++
++                // The hot loop provably crossed the trace compile threshold inside the
++                // collectible assembly (compilation is synchronous on this runtime), so the
++                // forced teardown must have released at least one trace-table slot. total-freed
++                // is monotonic, so no concurrent allocation can mask the release.
++                Assert.True(freedAfter > freedBefore,
++                    $"cycle {i}: the forced unload must release at least one jiterpreter trace-table slot " +
++                    $"(totalFreed before={freedBefore} after={freedAfter}, fresh={TraceStat(StatFreshAllocated)}, " +
++                    $"free={TraceStat(StatFreeCount)}, totalReused={TraceStat(StatTotalReused)}). " +
++                    "If totalFreed did not move, either no trace was compiled for the hot loop (jiterpreter disabled in this host?) " +
++                    "or the unload sweep failed to release the trace's slot.");
++            }
++
++            // Reuse: after the first cycle released slot(s), the free set was non-empty, and the
++            // allocator always prefers it — so the later cycles' guaranteed trace compilations
++            // (or any interleaved allocation) must have consumed released slots. total-reused is
++            // monotonic, making this deterministic without asserting an exact plateau.
++            int reusedAtEnd = TraceStat(StatTotalReused);
++            Assert.True(reusedAtEnd > reusedAtStart,
++                $"released trace-table slots must be reused by later allocations before fresh capacity is consumed " +
++                $"(totalReused start={reusedAtStart} end={reusedAtEnd}, fresh={TraceStat(StatFreshAllocated)}, " +
++                $"free={TraceStat(StatFreeCount)}, totalFreed={TraceStat(StatTotalFreed)}).");
++
++            // The reclamation must not have disturbed the ALC teardown itself: the forced-down
++            // contexts stay reclaimable.
++            CollectAndAssertDead(refs);
++        }
++
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static void RunDarkModeCycle()
++        {
++            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
++            RunHotLoop(context);
++            context.Unload();
++            GcQuiesce();
++
++            Assert.Equal(Rejected, Force(context));
++            Assert.Equal(-1, TraceStat(StatFreshAllocated));
++            Assert.Equal(-1, TraceStat(StatFreeCount));
++            Assert.Equal(-1, TraceStat(StatTotalFreed));
++            Assert.Equal(-1, TraceStat(StatTotalReused));
++            GC.KeepAlive(context);
++        }
++
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static WeakReference LoadRunHotLoopUnloadAndForce()
++        {
++            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
++            var weakRef = new WeakReference(context);
++            RunHotLoop(context);
++            context.Unload();
++            Assert.Equal(Completed, ForceUntilCompleted(context, 10));
++            context = null;
++            return weakRef;
++        }
++
++        // Drives the collectible assembly's trace bait over the jiterpreter's hit-count
++        // threshold. All reflection state is confined to this frame so the context can become
++        // quiescent once it returns.
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static void RunHotLoop(AssemblyLoadContext context)
++        {
++            Assembly asm = context.LoadFromAssemblyName(new AssemblyName(TestAssembly));
++            Type type = asm.GetType(TestClassName, throwOnError: true);
++            MethodInfo hotLoop = type.GetMethod("JiterpreterHotLoop", BindingFlags.Public | BindingFlags.Static);
++            Assert.NotNull(hotLoop);
++
++            object result = hotLoop.Invoke(null, new object[] { HotCalls });
++            Assert.IsType<int>(result);
++        }
++
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static void CollectAndAssertDead(WeakReference[] refs)
++        {
++            for (int attempt = 0; attempt < 10; attempt++)
++            {
++                GC.Collect();
++                GC.WaitForPendingFinalizers();
++
++                bool anyAlive = false;
++                foreach (WeakReference weakRef in refs)
++                {
++                    anyAlive |= weakRef.IsAlive;
++                }
++
++                if (!anyAlive)
++                {
++                    return;
++                }
++            }
++
++            foreach (WeakReference weakRef in refs)
++            {
++                Assert.False(weakRef.IsAlive,
++                    "A forced-down collectible AssemblyLoadContext should stay reclaimable after jiterpreter slot reclamation.");
++            }
++        }
++    }
++}
+diff --git a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs
+index 5cad40171..300d21636 100644
+--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs
++++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs
+@@ -1,6 +1,7 @@
+ // Licensed to the .NET Foundation under one or more agreements.
+ // The .NET Foundation licenses this file to you under the MIT license.
+ 
++using System.Runtime.CompilerServices;
+ using System.Runtime.InteropServices;
+ 
+ namespace System.Runtime.Loader.Tests
+@@ -35,6 +36,39 @@ public static void TestDelegateMarshalling()
+         public class COMClass
+         {
+         }
++
++        // Deterministic jiterpreter trace bait for the function-table slot-reclamation
++        // lifecycle tests. Called once with `calls` above the jiterpreter's trace hit-count
++        // threshold, it guarantees at least one trace entry point in THIS assembly crosses
++        // the threshold and compiles (synchronously, on the single-threaded browser runtime):
++        //   * the loop head here is a backward-branch target hit `calls` times, and
++        //   * JiterpreterHotBody's method-entry point is also hit `calls` times (the call is
++        //     NoInlining so the interpreter cannot fold it away),
++        // so a trace compiles whichever entry-point kinds the jiterpreter has enabled.
++        // The body is pure int arithmetic on locals — no calls, no allocations — so trace
++        // compilation cannot abort before reaching the minimum-trace-value heuristic.
++        public static int JiterpreterHotLoop(int calls)
++        {
++            int acc = 17;
++            for (int i = 0; i < calls; i++)
++            {
++                acc ^= JiterpreterHotBody(acc, i);
++            }
++
++            return acc;
++        }
++
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        public static int JiterpreterHotBody(int a, int i)
++        {
++            int b = a + i, c = a ^ i, d = i + 3;
++            a += b; b ^= c; c += d; d ^= a;
++            a += i; b += a; c ^= b; d += c;
++            a ^= d; b += i; c += a; d ^= b;
++            a += c; b ^= d; c += i; d += a;
++            a ^= b; b += c; c ^= d; d += i;
++            return a + b + c + d;
++        }
+     }
+ 
+     // Used to test LoaderAllocator used for a generic type instance allocation
+diff --git a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+index bbdad35cc..09a06f1b3 100644
+--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
++++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+@@ -32,6 +32,7 @@
+     <Compile Include="LoaderLinkTest.cs" />
+     <Compile Include="AssemblyResolutionDowngradeTest.cs" />
+     <Compile Include="ForcedNativeUnloadTests.cs" />
++    <Compile Include="JiterpreterTableReclamationTests.cs" />
+     <Compile Include="$(CommonTestPath)TestUtilities\System\DisableParallelization.cs" Link="Common\TestUtilities\System\DisableParallelization.cs" />
+     <EmbeddedResource Include="MainStrings*.resx" />
+   </ItemGroup>
+diff --git a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
+index cc30e0cdb..8682a1521 100644
+--- a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
++++ b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
+@@ -37,6 +37,7 @@ internal IntPtr NativeALC
+         [DynamicDependency(nameof(_nativeAssemblyLoadContext))]
+         [DynamicDependency(nameof(ForceNativeUnload))] // trim-root: hosts invoke this bridge via reflection
+         [DynamicDependency(nameof(GetScoutRetirementStats))] // trim-root: diagnostics bridge, invoked via reflection
++        [DynamicDependency(nameof(GetJiterpreterTableStat))] // trim-root: lifecycle tests invoke this bridge via reflection
+         private IntPtr InitializeAssemblyLoadContext(IntPtr thisHandlePtr, bool representsTPALoadContext, bool isCollectible)
+         {
+             if (isCollectible)
+@@ -78,6 +79,21 @@ private static void KeepLoaderAllocator()
+         // unconditional (not part of the DISABLE_THREADS-gated forced teardown).
+         internal static int GetScoutRetirementStats(int kind) => InternalGetScoutRetirementStats(kind);
+ 
++        [MethodImplAttribute(MethodImplOptions.InternalCall)]
++        private static extern int InternalGetJiterpreterTableStat(int table, int kind);
++
++        // Diagnostic bridge for the jiterpreter function-table slot-reclamation lifecycle tests.
++        // Mirrors mono_jiterp_get_table_stat (jiterpreter.c): `table` is a JITERPRETER_TABLE_*
++        // value (0 = traces) and `kind` selects the statistic (0 = fresh slots allocated,
++        // 1 = slots currently free, 2 = total slots ever released, 3 = total released slots ever
++        // reused). Returns -1 whenever slot reclamation is unavailable (non-browser runtime,
++        // threads-enabled build) or the MONO_WASM_ENABLE_ALC_UNLOAD opt-in is absent, so this
++        // surface is as dark by default as the feature it observes.
++        internal static int GetJiterpreterTableStat(int table, int kind)
++        {
++            return InternalGetJiterpreterTableStat(table, kind);
++        }
++
+         // Outcome of a host-triggered native ALC teardown. The values MUST stay in sync with the
+         // return codes of ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload
+         // in the native assembly-load-context.c.
+diff --git a/src/mono/browser/runtime/cwraps.ts b/src/mono/browser/runtime/cwraps.ts
+index e693c5223..c02fbd777 100644
+--- a/src/mono/browser/runtime/cwraps.ts
++++ b/src/mono/browser/runtime/cwraps.ts
+@@ -120,6 +120,7 @@ const fn_signatures: SigLine[] = [
+     [true, "mono_jiterp_is_special_interface", "number", ["number"]],
+     [true, "mono_jiterp_initialize_table", "void", ["number", "number", "number"]],
+     [true, "mono_jiterp_allocate_table_entry", "number", ["number"]],
++    [true, "mono_jiterp_free_table_entry", "number", ["number", "number"]],
+     [true, "mono_jiterp_get_interp_entry_func", "number", ["number"]],
+     [true, "mono_jiterp_get_counter", "number", ["number"]],
+     [true, "mono_jiterp_modify_counter", "number", ["number", "number"]],
+@@ -248,6 +249,8 @@ export interface t_Cwraps {
+     mono_jiterp_is_special_interface(klass: number): number;
+     mono_jiterp_initialize_table(type: number, firstIndex: number, lastIndex: number): void;
+     mono_jiterp_allocate_table_entry(type: number): number;
++    // returns 1 when the slot was accepted for reuse (forced ALC unload reclamation), 0 when refused
++    mono_jiterp_free_table_entry(type: number, index: number): number;
+     mono_jiterp_get_interp_entry_func(type: number): number;
+     mono_jiterp_get_counter(counter: number): number;
+     mono_jiterp_modify_counter(counter: number, delta: number): number;
+diff --git a/src/mono/browser/runtime/jiterpreter.ts b/src/mono/browser/runtime/jiterpreter.ts
+index 6ba17a3ab..5e778f857 100644
+--- a/src/mono/browser/runtime/jiterpreter.ts
++++ b/src/mono/browser/runtime/jiterpreter.ts
+@@ -1088,8 +1088,26 @@ export function mono_wasm_free_method_data (
+         mono_wasm_profiler_free_method(method);
+     }
+ 
+-    // TODO: Uninstall the trace function pointer from the function pointer table,
+-    //  so that the compiled trace module can be freed by the browser eventually
++    // Uninstall the compiled trace function from the function pointer table and recycle
++    //  its slot, so repeated assembly-load-context unload cycles do not permanently
++    //  consume table capacity (and so the engine can eventually collect the trace module).
++    // mono_jiterp_free_table_entry only accepts the release when the runtime opted into
++    //  forced ALC unload (MONO_WASM_ENABLE_ALC_UNLOAD on a single-threaded build) and the
++    //  slot is a real, not-already-released allocation, so default configurations keep
++    //  the upstream monotonic allocator behavior unchanged.
++    const info = traceInfo[traceIndex];
++    if (info && info.fnPtr) {
++        if (cwraps.mono_jiterp_free_table_entry(JiterpreterTable.Trace, info.fnPtr) > 0) {
++            // Repoint the slot at the safe placeholder (the same fill value used when the
++            //  table was created), so a stale indirect call through it bails out to the
++            //  interpreter instead of invoking a trace whose method has been freed.
++            getWasmFunctionTable().set(info.fnPtr, getRawCwrap("mono_jiterp_placeholder_trace"));
++            // Capacity is available again, so re-enable trace generation if the table had
++            //  filled up. (Traces already tiered to NOT_JITTED/nop stay that way; only
++            //  newly-created trace entry points benefit.)
++            traceTableIsFull = false;
++        }
++    }
+     // Release the trace info object, if present
+     delete traceInfo[traceIndex];
+     // Remove any AOT data and queue entries associated with the method
+diff --git a/src/mono/mono/metadata/assembly-load-context.c b/src/mono/mono/metadata/assembly-load-context.c
+index 382247fa9..206c1a653 100644
+--- a/src/mono/mono/metadata/assembly-load-context.c
++++ b/src/mono/mono/metadata/assembly-load-context.c
+@@ -617,6 +617,37 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+ #endif
+ }
+ 
++#if defined(HOST_BROWSER) && defined(DISABLE_THREADS)
++/*
++ * Implemented in mini/interp/jiterpreter.c, which is only built for the browser runtime
++ * (not the AOT cross compiler), hence the HOST_BROWSER guard on the reference here —
++ * same pattern as the jiterpreter sweep call in mini-runtime.c. Declared locally
++ * instead of including the mini-internal jiterpreter.h from metadata.
++ */
++extern gint32
++mono_jiterp_get_table_stat (int table, int kind);
++#endif
++
++int
++ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetJiterpreterTableStat (int table, int kind, MonoError *error)
++{
++	/*
++	 * Diagnostic bridge for the jiterpreter function-table slot-reclamation lifecycle
++	 * tests (see mono_jiterp_get_table_stat in jiterpreter.c for the table/kind values).
++	 * Returns -1 whenever the reclamation feature is unavailable: non-browser runtimes,
++	 * threads-enabled builds (the feature is compiled out there, exactly like
++	 * InternalForceNativeUnload above), or the MONO_WASM_ENABLE_ALC_UNLOAD opt-in being
++	 * absent — so this surface is as dark by default as the feature it observes.
++	 */
++#if defined(HOST_BROWSER) && defined(DISABLE_THREADS)
++	return mono_jiterp_get_table_stat (table, kind);
++#else
++	(void)table;
++	(void)kind;
++	return -1;
++#endif
++}
++
+ gpointer
+ ves_icall_System_Runtime_Loader_AssemblyLoadContext_GetLoadContextForAssembly (MonoReflectionAssemblyHandle assm_obj, MonoError *error)
+ {
+diff --git a/src/mono/mono/metadata/icall-def.h b/src/mono/mono/metadata/icall-def.h
+index 4e1a93423..e4ca6f1d6 100644
+--- a/src/mono/mono/metadata/icall-def.h
++++ b/src/mono/mono/metadata/icall-def.h
+@@ -473,6 +473,7 @@ NOHANDLES(ICALL(X86BASE_1, "__cpuidex", ves_icall_System_Runtime_Intrinsics_X86_
+ ICALL_TYPE(ALC, "System.Runtime.Loader.AssemblyLoadContext", ALC_5)
+ HANDLES(ALC_5, "GetLoadContextForAssembly", ves_icall_System_Runtime_Loader_AssemblyLoadContext_GetLoadContextForAssembly, gpointer, 1, (MonoReflectionAssembly))
+ HANDLES(ALC_7, "InternalForceNativeUnload", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload, int, 1, (gpointer))
++HANDLES(ALC_9, "InternalGetJiterpreterTableStat", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetJiterpreterTableStat, int, 2, (int, int))
+ HANDLES(ALC_4, "InternalGetLoadedAssemblies", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetLoadedAssemblies, MonoArray, 0, ())
+ HANDLES(ALC_8, "InternalGetScoutRetirementStats", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementStats, int, 1, (gint32))
+ HANDLES(ALC_2, "InternalInitializeNativeALC", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalInitializeNativeALC, gpointer, 4, (gpointer, const_char_ptr, MonoBoolean, MonoBoolean))
+diff --git a/src/mono/mono/mini/interp/interp.c b/src/mono/mono/mini/interp/interp.c
+index a47d81246..4db8b85bd 100644
+--- a/src/mono/mono/mini/interp/interp.c
++++ b/src/mono/mono/mini/interp/interp.c
+@@ -3743,15 +3743,17 @@ free_imethod_jiterp_cb (gpointer value, gpointer user_data)
+  * methods in an unloaded ALC would otherwise leak that metadata. Must run
+  * before interp_code_hash is destroyed.
+  *
+- * Scope: this does NOT reclaim WASM function-table slots. Compiled jiterpreter
+- * trace functions stay installed in the indirect function table, and the table
+- * allocator (mono_jiterp_allocate_table_entry) only ever advances next_index —
+- * slots are never released or reused — so repeated ALC load/unload cycles
+- * consume bounded table capacity. On exhaustion new traces simply stop being
+- * installed (allocate returns 0, logging "Jiterpreter table %d is out of
+- * space") and execution of those paths stays in the interpreter; installed
+- * traces keep working. Table-slot ownership/reuse is a tracked follow-up:
+- * https://github.com/unoplatform/Uno.DotnetRuntime.WebAssembly/issues/166
++ * Scope: WASM function-table slots owned by compiled traces of the swept
++ * methods are also reclaimed, but only when the runtime opted into forced ALC
++ * unload (MONO_WASM_ENABLE_ALC_UNLOAD on a single-threaded build): the JS side
++ * of the per-method sweep (mono_wasm_free_method_data) repoints each trace's
++ * slot at the safe placeholder and releases it to a per-table free set that
++ * mono_jiterp_allocate_table_entry consults before advancing next_index (see
++ * mono_jiterp_free_table_entry in jiterpreter.c). Without the opt-in the
++ * upstream monotonic allocator behavior is unchanged: slots are never released
++ * or reused, and on exhaustion new traces simply stop being installed
++ * (allocate returns 0, logging "Jiterpreter table %d is out of space") while
++ * execution of those paths stays in the interpreter.
+  */
+ void
+ mono_interp_free_mem_manager_jiterp (MonoJitMemoryManager *jit_mm)
+diff --git a/src/mono/mono/mini/interp/jiterpreter.c b/src/mono/mono/mini/interp/jiterpreter.c
+index 887038ca4..b323e8fcd 100644
+--- a/src/mono/mono/mini/interp/jiterpreter.c
++++ b/src/mono/mono/mini/interp/jiterpreter.c
+@@ -1476,6 +1476,46 @@ mono_jiterp_is_imethod_var_address_taken (InterpMethod *imethod, int offset) {
+ JiterpreterTableInfo tables[JITERPRETER_TABLE_LAST + 1] = { 0 };
+ int mono_jiterp_first_trace_fn_ptr = 0;
+ 
++#ifdef DISABLE_THREADS
++/*
++ * Function-table slot reclamation for host-triggered native unload of collectible
++ * AssemblyLoadContexts (opt-in via MONO_WASM_ENABLE_ALC_UNLOAD, see mono_alc_init in
++ * assembly-load-context.c). The upstream allocator below is monotonic: slots owned by
++ * traces of unloaded methods were never released or reused (dotnet/runtime#89980 scoped
++ * table-entry reuse out), so a long-lived worker that repeatedly loads and unloads
++ * assemblies would permanently consume table capacity.
++ *
++ * Per table we keep a bitset of released slots (bit N <=> slot first_index + N is free)
++ * plus a live free count and two monotonic diagnostic counters. The bitset makes a
++ * double release structurally impossible (the second release sees the bit already set
++ * and is refused), matching the idempotence discipline of the forced-unload path that
++ * drives it. Like that path, the whole feature is hard-gated to the single-threaded
++ * build: uninstalling a table entry races concurrent indirect calls through it on a
++ * threads-enabled runtime, so there mono_jiterp_free_table_entry refuses every release
++ * and the allocator behaves exactly as before.
++ */
++static MonoBitSet *table_free_slots [JITERPRETER_TABLE_LAST + 1] = { NULL };
++static gint32 table_free_counts [JITERPRETER_TABLE_LAST + 1] = { 0 };
++static gint32 table_total_freed [JITERPRETER_TABLE_LAST + 1] = { 0 };
++static gint32 table_total_reused [JITERPRETER_TABLE_LAST + 1] = { 0 };
++
++static gboolean
++jiterp_table_reclamation_enabled (void) {
++	/*
++	 * Mirrors the explicit MONO_WASM_ENABLE_ALC_UNLOAD opt-in in mono_alc_init
++	 * (assembly-load-context.c): only "1"/"true" enable; unset/empty/"0"/"false"
++	 * keep the feature fully dark so default consumers see zero change.
++	 */
++	static int enabled = -1;
++	if (enabled == -1) {
++		char *val = g_getenv ("MONO_WASM_ENABLE_ALC_UNLOAD");
++		enabled = (val && (!g_ascii_strcasecmp (val, "1") || !g_ascii_strcasecmp (val, "true"))) ? 1 : 0;
++		g_free (val);
++	}
++	return enabled != 0;
++}
++#endif // DISABLE_THREADS
++
+ static void
+ atomically_set_value_once (gint32 *address, gint32 value) {
+ #ifdef DISABLE_THREADS
+@@ -1530,6 +1570,17 @@ mono_jiterp_allocate_table_entry (int type) {
+ #ifdef DISABLE_THREADS
+ 	if (table->next_index == 0)
+ 		table->next_index = table->first_index;
++	// Prefer a slot released by a forced AssemblyLoadContext unload over consuming fresh
++	//  capacity. The free set is only ever populated when the reclamation opt-in is active
++	//  (mono_jiterp_free_table_entry), so default configurations never take this path.
++	if (table_free_counts [type] > 0) {
++		int free_bit = mono_bitset_find_first (table_free_slots [type], -1);
++		g_assert (free_bit >= 0);
++		mono_bitset_clear (table_free_slots [type], free_bit);
++		table_free_counts [type]--;
++		table_total_reused [type]++;
++		return table->first_index + free_bit;
++	}
+ 	int index = table->next_index++;
+ #else
+ 	gint32 expected = 0;
+@@ -1546,6 +1597,88 @@ mono_jiterp_allocate_table_entry (int type) {
+ 	return index;
+ }
+ 
++/*
++ * Release a function-table slot that belonged to a trace of a method being freed, so a
++ * later allocation can reuse it. Returns 1 when the slot was accepted onto the free set,
++ * 0 when the release was refused; the JS caller (mono_wasm_free_method_data) only
++ * repoints the table entry at the safe placeholder when the release was accepted.
++ *
++ * Refusal is the SAFE outcome and covers: threads-enabled builds (uninstalling races
++ * concurrent indirect calls, so the feature is compiled out just like the forced ALC
++ * unload it serves); the MONO_WASM_ENABLE_ALC_UNLOAD opt-in being absent (default
++ * consumers keep the upstream monotonic allocator, zero behavior change); indexes that
++ * were never handed out by mono_jiterp_allocate_table_entry (out of range or beyond
++ * next_index, which also rejects the JITERPRETER_TRAINING/NOT_JITTED sentinel values 0/1
++ * because real slots start at first_index > 1); and slots that are already on the free
++ * set (double-release guard, mirroring the idempotence discipline of the forced-unload
++ * path that drives this).
++ */
++EMSCRIPTEN_KEEPALIVE int
++mono_jiterp_free_table_entry (int type, int index) {
++#ifndef DISABLE_THREADS
++	(void)type;
++	(void)index;
++	return 0;
++#else
++	if (!jiterp_table_reclamation_enabled ())
++		return 0;
++	if ((type < 0) || (type > JITERPRETER_TABLE_LAST))
++		return 0;
++	JiterpreterTableInfo *table = &tables[type];
++	if (table->first_index <= 0)
++		return 0;
++	if ((index < table->first_index) || (index > table->last_index) || (index >= table->next_index))
++		return 0;
++	guint32 bit = index - table->first_index;
++	if (!table_free_slots [type])
++		table_free_slots [type] = mono_bitset_new (table->last_index - table->first_index + 1, 0);
++	if (mono_bitset_test (table_free_slots [type], bit))
++		return 0;
++	mono_bitset_set (table_free_slots [type], bit);
++	table_free_counts [type]++;
++	table_total_freed [type]++;
++	return 1;
++#endif
++}
++
++/*
++ * Diagnostic bridge for the slot-reclamation lifecycle tests (reached through the
++ * InternalGetJiterpreterTableStat icall in assembly-load-context.c). Returns -1 when the
++ * reclamation feature is unavailable (threads-enabled build) or not opted into, so the
++ * stats surface stays as dark as the feature itself. The kind values MUST stay in sync
++ * with the managed test consumer:
++ *   0 = fresh slots handed out by advancing next_index (excludes reused slots)
++ *   1 = slots currently sitting on the free set
++ *   2 = total slots ever released (monotonic)
++ *   3 = total released slots ever reused by the allocator (monotonic)
++ */
++gint32
++mono_jiterp_get_table_stat (int type, int kind) {
++#ifndef DISABLE_THREADS
++	(void)type;
++	(void)kind;
++	return -1;
++#else
++	if (!jiterp_table_reclamation_enabled ())
++		return -1;
++	if ((type < 0) || (type > JITERPRETER_TABLE_LAST))
++		return -1;
++	JiterpreterTableInfo *table = &tables[type];
++	switch (kind) {
++		case 0:
++			return (table->first_index > 0) ? (table->next_index - table->first_index) : 0;
++		case 1:
++			return table_free_counts [type];
++		case 2:
++			return table_total_freed [type];
++		case 3:
++			return table_total_reused [type];
++		default:
++			return -1;
++	}
++#endif
++}
++
+ int
+ mono_jiterp_increment_counter (volatile int *counter) {
+ #ifdef DISABLE_THREADS
+-- 
+2.53.0.vfs.0.0
+

--- a/patches/0012-reclaim-jiterpreter-table-slots-on-forced-alc-unload.patch
+++ b/patches/0012-reclaim-jiterpreter-table-slots-on-forced-alc-unload.patch
@@ -99,7 +99,10 @@ upstream monotonic one.
     no-trace sentinel sweep is exercised for real: it invokes a
     deliberately jiterpreter-ineligible collectible method once
     (creating an InterpMethod in the collectible memory manager
-    without any trace entry points), asserts the sentinel-sweep
+    without any trace entry points; the bait is NoInlining because
+    the interp transform inlines small callees without ever creating
+    an InterpMethod for them, which would leave the sweep nothing to
+    visit), asserts the sentinel-sweep
     counter moved during the forced unload, and asserts total-freed
     did not -- with the old 0 sentinel that sweep would have released
     the live trace-0 slot of a default-ALC method. With the flag off
@@ -120,8 +123,8 @@ Fixes https://github.com/unoplatform/Uno.DotnetRuntime.WebAssembly/issues/166
 Refs dotnet/runtime#89980.
 ---
  .../tests/ForcedNativeUnloadTests.cs          |  15 +-
- .../tests/JiterpreterTableReclamationTests.cs | 440 ++++++++++++++++++
- .../TestClass.cs                              |  46 ++
+ .../tests/JiterpreterTableReclamationTests.cs | 443 ++++++++++++++++++
+ .../TestClass.cs                              |  55 +++
  .../tests/System.Runtime.Loader.Tests.csproj  |   1 +
  .../Loader/AssemblyLoadContext.Mono.cs        |  17 +
  src/mono/browser/runtime/cwraps.ts            |   3 +
@@ -130,7 +133,7 @@ Refs dotnet/runtime#89980.
  src/mono/mono/metadata/icall-def.h            |   1 +
  src/mono/mono/mini/interp/interp.c            |  20 +-
  src/mono/mono/mini/interp/jiterpreter.c       | 173 ++++++-
- 11 files changed, 759 insertions(+), 24 deletions(-)
+ 11 files changed, 771 insertions(+), 24 deletions(-)
  create mode 100644 src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs
 
 diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
@@ -161,10 +164,10 @@ index a30a5a290..60708a1b5 100644
          {
 diff --git a/src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs b/src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs
 new file mode 100644
-index 000000000..62275c790
+index 000000000..ff6e02f70
 --- /dev/null
 +++ b/src/libraries/System.Runtime.Loader/tests/JiterpreterTableReclamationTests.cs
-@@ -0,0 +1,440 @@
+@@ -0,0 +1,443 @@
 +// Licensed to the .NET Foundation under one or more agreements.
 +// The .NET Foundation licenses this file to you under the MIT license.
 +
@@ -536,8 +539,11 @@ index 000000000..62275c790
 +        // mono_interp_get_imethod to create an InterpMethod in the collectible memory manager's
 +        // interp_code_hash — which is what the unload sweep iterates — while the method's
 +        // straight-line body guarantees the transform emitted no trace entry points for it, so the
-+        // sweep must take the no-trace sentinel branch for it. (Merely loading types via
-+        // reflection creates no InterpMethod and would leave this test vacuous.)
++        // sweep must take the no-trace sentinel branch for it. Two ways this can silently go
++        // vacuous, both guarded by the sentinel-sweep counter assertion above: merely loading
++        // types via reflection creates no InterpMethod, and a bait small enough for the
++        // interpreter transform to INLINE into the invoke wrapper never gets an InterpMethod
++        // either (hence the bait's load-bearing NoInlining attribute).
 +        [MethodImpl(MethodImplOptions.NoInlining)]
 +        private static void InvokeWithoutCompilingATrace(AssemblyLoadContext context)
 +        {
@@ -606,7 +612,7 @@ index 000000000..62275c790
 +    }
 +}
 diff --git a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs
-index 7d3bb5ebe..ede632a92 100644
+index 7d3bb5ebe..65d941c84 100644
 --- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs
 +++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs
 @@ -1,6 +1,7 @@
@@ -617,7 +623,7 @@ index 7d3bb5ebe..ede632a92 100644
  using System.Runtime.InteropServices;
  
  namespace System.Runtime.Loader.Tests
-@@ -35,6 +36,51 @@ public static void TestDelegateMarshalling()
+@@ -35,6 +36,60 @@ public static void TestDelegateMarshalling()
          public class COMClass
          {
          }
@@ -650,6 +656,15 @@ index 7d3bb5ebe..ede632a92 100644
 +        // emits NO trace entry points for it. Invoking it once therefore creates an
 +        // InterpMethod in this collectible assembly's memory manager that owns no trace —
 +        // exactly the shape whose unload sweep must take the no-trace sentinel path.
++        //
++        // NoInlining is LOAD-BEARING, not hygiene: the interpreter transform inlines small
++        // methods into their caller (interp_method_check_inlining), and an inlined callee
++        // never gets an InterpMethod at all — mono_interp_get_imethod only runs when a real
++        // MINT_CALL is emitted. Without the attribute this body is tiny enough to be inlined
++        // into the reflection-invoke wrapper, nothing lands in the collectible ALC's
++        // interp_code_hash, and the unload sweep has nothing to visit — the exact vacuity the
++        // regression test guards against (and how its CI guard first tripped).
++        [MethodImpl(MethodImplOptions.NoInlining)]
 +        public static int JiterpreterNoTraceBait(int value)
 +        {
 +            return value + 1;

--- a/scripts/check-loader-results.sh
+++ b/scripts/check-loader-results.sh
@@ -66,6 +66,7 @@ GlobalAssemblyEnumeration_SkipsCondemnedAssembly_WithoutAbortOrResurrection
 ForcedUnload_RootedPointerFreeObjects_BlockNativeFree
 JiterpreterTableStat_SurfaceMatchesOptIn
 ForcedUnload_ReclaimsJiterpreterTraceTableSlots
+ForcedUnload_WithoutAnyCompiledTrace_ReleasesNoSlots
 "
 if [ "$mode" = "mt" ]; then
   # The threads-enabled rejection test is [ConditionalFact(IsThreadingSupported)]: it self-skips

--- a/scripts/check-loader-results.sh
+++ b/scripts/check-loader-results.sh
@@ -67,6 +67,7 @@ ForcedUnload_RootedPointerFreeObjects_BlockNativeFree
 JiterpreterTableStat_SurfaceMatchesOptIn
 ForcedUnload_ReclaimsJiterpreterTraceTableSlots
 ForcedUnload_WithoutAnyCompiledTrace_ReleasesNoSlots
+JiterpreterTableAllocator_ExhaustionSelfTest
 "
 if [ "$mode" = "mt" ]; then
   # The threads-enabled rejection test is [ConditionalFact(IsThreadingSupported)]: it self-skips

--- a/scripts/check-loader-results.sh
+++ b/scripts/check-loader-results.sh
@@ -64,6 +64,8 @@ ReflectionHashInit_UnderGcPressure_StaysCoherent_AndHolderHandlesDoNotLeak
 ReflectionOverManyMembers_CrossesWeakRefobjectRehashBoundary
 GlobalAssemblyEnumeration_SkipsCondemnedAssembly_WithoutAbortOrResurrection
 ForcedUnload_RootedPointerFreeObjects_BlockNativeFree
+JiterpreterTableStat_SurfaceMatchesOptIn
+ForcedUnload_ReclaimsJiterpreterTraceTableSlots
 "
 if [ "$mode" = "mt" ]; then
   # The threads-enabled rejection test is [ConditionalFact(IsThreadingSupported)]: it self-skips


### PR DESCRIPTION
Fixes #166. **Stacked on #168** (base is `dev/nr/interp-volatile-barrier-intrinsic`; the diff shows only this work). Retarget to `main` once #168 merges. Patches 0001-0011 are unchanged by this PR — all new content ships as **`patches/0012-reclaim-jiterpreter-table-slots-on-forced-alc-unload.patch`**.

> Re-stacked: was on #162 (merged). #168 advances `DOTNETRUNTIME_COMMIT` to `release/10.0` head and now also carries #170 (`fix(sgen)`, merged into it), which modifies patches `0009` and `0011`. Since this PR's `0012` patches a file that `0011` creates, the two are validated as one stack — see Validation.

## Problem

Patch 0009's forced native unload reclaims a collectible AssemblyLoadContext's managed/native heap, but compiled jiterpreter trace functions stayed installed in the WASM indirect function table forever: `mono_jiterp_allocate_table_entry` only ever advances `next_index` (upstream scoped table-entry reuse out in dotnet/runtime#89980). A downstream host loading previewed apps into collectible ALCs therefore permanently consumed trace-table capacity per load/unload cycle; on exhaustion new traces stop installing and newly-hot paths stay on the interpreter — performance-only, but unbounded in a long-lived worker.

## Design

**Ownership — derived from the existing sweep, no new allocation-side structure.** The TS runtime already records each compiled trace's installed slot (`traceInfo[traceIndex].fnPtr`), and `mono_wasm_free_method_data` is already invoked once per trace entry point of every method being freed (by patch 0009's memory-manager sweep on forced unload, and by `interp_free_method` for dynamic methods). That callback now offers the recorded slot back to the native allocator. This was the smaller and provably-correct option from the issue: trace-info knows its slot, so ownership follows the per-method sweep that patch 0009 already runs.

**Release — `mono_jiterp_free_table_entry(type, index)`** (new `EMSCRIPTEN_KEEPALIVE` export, crossing the boundary via `cwraps` exactly like `mono_jiterp_allocate_table_entry`): validates the index is a real allocation of that table (within `[first_index, last_index]` and below `next_index`, which also rejects the `TRAINING`/`NOT_JITTED` sentinels 0/1) and pushes it onto a per-table free **bitset**.

**Double-free is structurally impossible**: a second release of the same slot sees the bit already set and is refused (returns 0) — mirroring the idempotence discipline of the 0009 free path. The TS side additionally deletes `traceInfo[traceIndex]` after the release, so a repeated sweep of the same trace has nothing to offer. The JS caller only uninstalls the table entry when the release was accepted.

**Stub semantics — safe against stale indirect calls**: an accepted slot is repointed at `mono_jiterp_placeholder_trace`, the exact fill value that every build pre-populates trace tables with (`jiterpreter-support.ts`, unguarded by thread mode), so an accepted release restores the slot to its pristine as-created state. A stale call through a released slot returns the ENTER-opcode displacement and execution continues in the interpreter (the "not jitted" semantics the interpreter already handles) — no trap, no freed-trace execution. This is defense-in-depth: 0009's whole-set quiescence gate already guarantees no frame of the dying ALC is live when the sweep runs, and the only call sites of a trace slot live in the dying method's own interp code, which is freed with it.

**Reuse — free list before growth**: `mono_jiterp_allocate_table_entry` (in its `DISABLE_THREADS` branch only) consumes the free set before advancing `next_index`, so steady-state load/unload cycles stop consuming fresh capacity. The TS `traceTableIsFull` latch is cleared when a release is accepted, so trace generation resumes even after prior exhaustion (traces already tiered to NOP/`NOT_JITTED` stay that way; only new entry points benefit).

**Gating — identical to patch 0009**: every new behavior requires the `MONO_WASM_ENABLE_ALC_UNLOAD` opt-in (same env parse as `mono_alc_init`) AND the single-threaded build (`DISABLE_THREADS` — uninstalling a table entry races concurrent indirect calls on a threads-enabled runtime, so there every release is refused). Default consumers keep the upstream monotonic allocator byte-for-byte.

## Measured assertion (issue deliverable 3)

New diagnostic icall `InternalGetJiterpreterTableStat(table, kind)` on the same internal type as `InternalForceNativeUnload`, exposing per-table `{fresh next_index allocations, current free count, monotonic total-freed, monotonic total-reused}`; it returns `-1` whenever reclamation is unavailable or not opted in, so the surface is as dark as the feature. Trim-rooted via `DynamicDependency` like the 0009 bridge, and covered by the same `MONO_WASM_ALC_UNLOAD_REQUIRE_BRIDGE` fail-loudly check.

New `JiterpreterTableReclamationTests` (System.Runtime.Loader.Tests) run in both CI env modes:

* **Flag ON**: three load → hot-loop → `Unload()` → force-`Completed` cycles against a trace-bait method added to the loader test assembly (pure int arithmetic, driven 12,000× — well above the default 5,000 hit-count threshold; trace compilation is **synchronous** at the threshold on the single-threaded runtime, so at least one trace provably compiles inside the collectible assembly each cycle). Asserts: (a) every cycle's forced unload increases the monotonic **total-freed** counter; (b) released slots are consumed by later allocations (**total-reused** increases — the allocator always prefers the free set, so this is invariant-driven, not timing-driven); (c) the forced-down ALCs still die under GC.
* **Why not an exact `next_index` plateau**: trace entry points in default-ALC code (CoreLib/xunit) accumulate hit counts *across* cycles and can cross the compile threshold at unpredictable moments, so a plateau assertion would be flaky. The monotonic-counter assertions cannot be; they directly prove "freed > 0 and a later allocation consumed a freed slot", which is the reuse property the issue asked to prove. No `Assert.Inconclusive`, no env-conditional skips — the dark-mode legs assert the dark surface instead.
* **Flag OFF** (and threads-enabled runtimes): the stats report unavailable (`-1`), the force stays `Rejected`, invalid table/kind arguments are always refused — the zero-change guarantee, asserted.

`scripts/check-loader-results.sh` now requires both new tests to be present and passing on both legs (they always run; nothing env-gated was added to the required list).

## Scope — still not covered (documented in the patch header)

* Only `JITERPRETER_TABLE_TRACE` slots are released (the sweep only knows trace ownership). The jit-call / interp-entry wrapper tables are sized 1 in non-AOT browser builds and only populated under AOT, so they are not a leak vector for the interpreter-based unload scenario; their slots remain unreclaimed.
* Trace **indexes** (`trace_info` segment space) remain monotonic — only WASM function-table slots are reused. Pre-existing bounded residual, unchanged for default consumers.

## Repo-side changes (outside the patch)

* `check-loader-results.sh`: three new required lifecycle tests.
* `runtime-ci.yml` / `conventional-commits.yml`: trigger on PRs targeting `dev/**` so this stacked PR (and future ones) runs the same runtime CI and commit checks as PRs to `main`.
* `.mergify.yml`: Mergify-performed merges of stacked (`base~=^dev/`) PRs now require `check-success=ci_ok` and the conventional-commits check, plus the same review/label bar as the main-branch rule.

### Merge-gating limitation (documented, not fixable in-repo)

The `dev/**` triggers only **schedule** checks and the Mergify rule only gates **Mergify-performed** merges. A manual merge-button press on a stacked PR is not blocked by anything in this repository — that requires an admin-side repository ruleset (or classic branch protection) targeting `dev/**` and requiring the `ci_ok` status check (recommended: also `Validate for conventional commits`). Until that ruleset exists, stacked PRs can still be merged while checks run or fail (as #170 was).

## Validation

Fresh checkout of the then-pinned base -> `git apply --check --whitespace=fix` of patches 0001->0012 in sorted production order: all clean; the applied tree is byte-identical to the development tree the diff was generated from (`git diff` empty).

**Re-verified against the new base and the full stack** (`742e2f077a0c`, `release/10.0` head, with #170's modified `0009`/`0011` in place): patches `0001`-`0012` all apply in sorted production order. This is the check git cannot make — #170 and this PR touch disjoint files at the repo level, so a clean merge says nothing about whether `0012`'s hunks into `ForcedNativeUnloadTests.cs` still land on the version of that file `0011` now produces. They do.

**Round-12 revalidation** (post-#173 merge, review-round fixes): patch `0012` regenerated from the applied tree against the merged `0001`–`0011` stack at pin `742e2f07`. Fresh checkout → `git apply --check` of all 12 patches in sorted order passes both plain and with `--whitespace=fix`, and both applied trees are byte-identical to the resolution tree (tree `a0cd78c0da60`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


