### PR TITLE
fix(runtime): advance DOTNETRUNTIME_COMMIT to release/10.0 head

### DIFF
--- a/.github/workflows/runtime-ci.yml
+++ b/.github/workflows/runtime-ci.yml
@@ -13,7 +13,7 @@ on:
       - release/**
 
 env:
-  DOTNETRUNTIME_COMMIT: 081d220c0a773ffb7c6bea6b48727833576a65ef
+  DOTNETRUNTIME_COMMIT: 742e2f077a0c7d79bf57d6dd01d571a06f3a4738
   DOTNETSDK_VERSION: 10.0.100
   ADDITIONAL_BUILD_ARGS: '/p:MonoEnableAssertMessages=true /p:WasmEnableES6=true /p:WasmExceptionHandling=true'
   NBGV_VERSION: 3.9.50


### PR DESCRIPTION
> **Approach changed.** This PR originally added `patches/0012-*.patch` cherry-picking one upstream hunk. It now advances the pin instead — the patch was only ever a workaround for a stale pin, and the stale pin is the actual problem. The branch name still reflects the original approach. Diff is one line.
>
> **Base of a three-PR stack:** `main` ← **#168 (here)** ← #171 (sgen) ← #167 (jiterp).

## Problem

`DOTNETRUNTIME_COMMIT` is pinned at `081d220c` (`release/10.0`, **2026-02-18**). Six months of servicing behind, and specifically missing the Mono interpreter intrinsic for `Volatile.ReadBarrier` / `Volatile.WriteBarrier`.

Both are new `[Intrinsic]` methods in .NET 10 whose managed fallback body is **literally a call to themselves**:

```
=== System.Threading.Volatile.ReadBarrier ===
  [attr] System.Runtime.CompilerServices.IntrinsicAttribute
  IL size: 6 bytes
  IL bytes: 28 14 43 00 06 2A        // call Volatile::ReadBarrier ; ret
```

They are only correct when the execution engine expands the intrinsic. `interp_handle_intrinsics` handled `Thread.MemoryBarrier` but had no `Volatile` case, so an interpreted call fell through to the managed body and recursed until the stack was gone:

```
Unhandled Exception:
StackOverflowException
[ERROR] FATAL UNHANDLED EXCEPTION: System.StackOverflowException
  at System.Threading.Volatile.ReadBarrier ()
  at System.Threading.Volatile.ReadBarrier ()
  ... (thousands of identical frames, no user code)
```

This is not fork-specific — Microsoft's `Microsoft.NETCore.App/10.0.x` corelib has the same shape. What was missing is interpreter-side expansion.

**Impact:** reachable on `browser-wasm` from **any** interpreted code path calling `Volatile.Read`/`Write` — in practice, any managed code built for `net10.0` not covered by an AOT profile. A WASM worker hosting a `net10.0` build of Roslyn dies a few seconds after runtime start (`.NET runtime already exited with 1`). It also makes AOT-profile capture impossible for such a consumer: capture runs interpreter-only, so no profile can cover the crashing path.

Fixed upstream in [dotnet/runtime#124538](https://github.com/dotnet/runtime/pull/124538) (`main`) and backported in [dotnet/runtime#130303](https://github.com/dotnet/runtime/pull/130303) (`release/10.0`, merged 2026-08-06).

Worth noting: `10.0.0-dev-0054` published 2026-08-06T14:40Z, **twenty minutes after** that backport merged — from a build that started before it. So the newest published pack does not carry the fix; only moving the pin does.

## Change

`081d220c` → `742e2f07` (`release/10.0` head, 2026-08-07).

```
ahead_by: 140, behind_by: 0
```

A straight fast-forward on the servicing branch — no merge, no history divergence.

## Patch rebase cost: zero (verified, not assumed)

I materialized every file the patches touch at `742e2f07` and applied all of them in order with `git apply --whitespace=fix`, exactly as `scripts/apply-patches.ps1` does:

| Patch | Result |
|---|---|
| `0001` hot-reload propertymap/eventmap crash | ✅ applies |
| `0002` runtime-already-exited error loop | ✅ applies |
| `0003` hot-reload field-add typedef guard | ✅ applies |
| `0004` hot-reload nested-class token mismatch | ✅ applies |
| `0005` wasm LMF null-method unwind crash | ✅ applies |
| `0006` hot-reload eventmap assert typo | ✅ applies |
| `0007` AOT gsharedvt out wrappers | ✅ applies |
| `0008` interp gsharedvt fallback | ✅ applies |
| `0009` host-triggered native ALC unload | ✅ applies |
| `0010` weak-hash rehash on ST runtime | ✅ applies |
| `0011` forced-native-unload lifecycle tests | ✅ applies |

No patch needed rebasing. That all 11 still apply also confirms upstream has not absorbed any of them — they are all still carrying their weight.

## Reviewer note — gsharedvt overlap

The new base's head commit is `[mono][AOT] gsharedvt - stop validating generic constraints (#131735)`, and this repo carries **two** gsharedvt patches (`0007`, `0008`). They apply cleanly, but *textually clean is not semantically clean* — worth a read to confirm upstream's change does not overlap or supersede them. `test_loader_wasm` / `test_loader_wasm_mt` plus the three AOT build jobs should surface a functional conflict if there is one.

This is also an argument **for** the bump rather than against it: that area is being actively fixed upstream, and staying six months back means diverging from it.

## Why not a patch, and why not `main`

- **A patch** (`0012-add-interp-intrinsic-*.patch`, this PR's original form) works, but it hand-maintains a hunk that upstream already ships, without upstream's `VolatileTests.cs` coverage, and leaves the pin stale for the next person. Against the new base that patch fails to apply *because the fix is already there* — which is the cleanest possible argument for deleting it.
- **`main`** is `11.0.0` (`eng/Versions.props`). Building from it would publish a .NET 11 runtime as `Uno.NETCore.App.Runtime.Mono.browser-wasm 10.0.0-dev-*`, consumed by `net10.0-browserwasm` heads. Not a rebase — a major-version migration.

## Risk

140 commits of `release/10.0` servicing is real surface, and this PR does not pretend otherwise. It is bug-fix-only by branch policy, the patch set is unaffected, and CI (`ci_ok` over 3× AOT builds, the Linux build, and both loader-wasm test jobs) is the verdict. The counterfactual is not zero risk — it is the same risk deferred and compounding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
