### PR TITLE
fix(sgen): root the collectible witness from pointer-free objects in every scan path

### DIFF
--- a/patches/0009-host-triggered-native-unload-of-collectible-alcs-on-wasm-worker.patch
+++ b/patches/0009-host-triggered-native-unload-of-collectible-alcs-on-wasm-worker.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nick Randolph <noreply@platform.uno>
-Date: Mon, 6 Jul 2026 00:00:00 +0000
+Date: Fri, 7 Aug 2026 00:00:00 +0000
 Subject: [PATCH] feat: host-triggered native unload of collectible
  AssemblyLoadContexts on a WASM worker
 
@@ -324,6 +324,76 @@ assemblies filtered from the global enumeration):
     mono_weak_hash_table_dead_lookup_count (unconditional, like kinds
     2/3/5) so the lifecycle test can prove the enumeration really took
     the dead-cache path instead of passing vacuously.
+
+Round 11 (downstream crash follow-up: pointer-free instances must keep
+their collectible LoaderAllocator witness alive in every scan path):
+
+  A downstream host loading previewed apps into collectible ALCs on
+  browser-wasm (flag ON, single-threaded, interpreter) observed, after
+  several unload cycles whose forces did not all complete, a fatal GC
+  assertion during a later collection:
+
+    * Assertion: should not be reached at .../sgen/sgen-scan-object.h:93
+
+  That line is the default case of the object-scan descriptor switch
+  (upstream code, untouched by this patch series), reachable only when
+  an object's descriptor has 0 in its low type bits — i.e. when the
+  descriptor was read through a dangling vtable (freed memory typically
+  holds an aligned free-list pointer there, whose low three bits are
+  000). Root cause, established in the applied tree:
+
+  * The quiescence gate above reads each manager's LoaderAllocator
+    weak-handle target, and the LoaderAllocator is kept alive PER SCAN:
+    every scanned object of a collectible class reports its vtable's
+    class object (sgen-scan-object.h's trailing HANDLE_PTR block,
+    upstream collectible-ALC machinery).
+  * An object whose descriptor has no reference slots (pointer-free
+    class instances, arrays of pointer-free value types) is only pushed
+    to the gray stack — and hence scanned — where the enqueue condition
+    is collectible-aware. Upstream made the in-place major mark macros
+    (MS_MARK_OBJECT_AND_ENQUEUE/_PAR: has_references OR
+    sgen_vtable_has_class_obj) aware, but NOT:
+      - copy_object_no_checks / copy_object_no_checks_par
+        (sgen-copy-object.h) — every nursery promotion/evacuation copy;
+      - the LOS branch of the major gray-stack drain
+        (sgen-marksweep-drain-gray-stack.h);
+      - sgen_los_pin_objects (sgen-los.c) — conservatively pinned LOS.
+  * A live POINTER-FREE object of a collectible class in the large
+    object space (e.g. a big array of an unloadable value type)
+    therefore never roots its witness at ANY major collection; a small
+    pointer-free instance has the same exposure in the exact collection
+    that promotes it out of the nursery. Once every reference-carrying
+    root is gone, the witness dies while such instances are still live,
+    the force (correctly trusting the witness) reports Completed,
+    mono_alc_cleanup frees the manager — and with it the instances'
+    MonoVTables — and the next collection that marks a still-live
+    instance reads a garbage descriptor through the dangling vtable and
+    hits the assertion. Upstream never reaches this state because its
+    teardown chain is disabled; the forced free makes witness
+    completeness load-bearing.
+
+  Fix: make the three remaining enqueue conditions collectible-aware,
+  identical to MS_MARK_OBJECT_AND_ENQUEUE (has_references ||
+  sgen_vtable_has_class_obj). An enumeration of every gray-stack
+  enqueue site in the applied tree shows the remaining ones (the
+  nursery pin queue and the late OOM pin_object) already enqueue
+  unconditionally, and scanning a pointer-free descriptor is a no-op
+  switch case followed by the class-object report, so the change is
+  well-defined for every descriptor type.
+
+  Safety direction: the fix makes the witness live LONGER (it now also
+  reflects genuinely live pointer-free instances), so a force that
+  would previously have freed live memory now reports NotQuiescent
+  until those instances are released — strictly more conservative, and
+  nothing is ever reported through a freed pointer. Cost: one NULL
+  field check per copied/pinned pointer-free object (non-collectible
+  vtables have a NULL loader_alloc), the same check the major mark
+  macro already pays.
+  SHARED-CODE IMPACT: unconditional (not behind the opt-in), because
+  witness completeness is what makes upstream's own collectible-ALC
+  accounting truthful; with the flag off no ALC is collectible, every
+  vtable has a NULL loader_alloc, and behaviour is unchanged. Arguably
+  upstreamable as-is.
 ---
  .../Runtime/Loader/AssemblyLoadContext.cs     |   7 +-
  .../Loader/AssemblyLoadContext.Mono.cs        | 108 ++++-
@@ -339,7 +409,10 @@ assemblies filtered from the global enumeration):
  src/mono/mono/mini/interp/interp.c            |  36 ++
  src/mono/mono/mini/interp/interp.h            |   3 +
  src/mono/mono/mini/mini-runtime.c             |   5 +
- 14 files changed, 896 insertions(+), 44 deletions(-)
+ src/mono/mono/sgen/sgen-copy-object.h         |  15 +-
+ src/mono/mono/sgen/sgen-los.c                 |   7 +-
+ .../sgen/sgen-marksweep-drain-gray-stack.h    |   9 +-
+ 17 files changed, 923 insertions(+), 48 deletions(-)
 
 diff --git a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
 index 9f9403738..4eac33a24 100644
@@ -1679,6 +1752,77 @@ index 7cf63847f..760ca0bf9 100644
  	mono_internal_hash_table_destroy (&info->interp_code_hash);
  #ifdef ENABLE_LLVM
  	mono_llvm_free_mem_manager (info);
+diff --git a/src/mono/mono/sgen/sgen-copy-object.h b/src/mono/mono/sgen/sgen-copy-object.h
+index 17a6e64fa..0692863ce 100644
+--- a/src/mono/mono/sgen/sgen-copy-object.h
++++ b/src/mono/mono/sgen/sgen-copy-object.h
+@@ -82,7 +82,17 @@ copy_object_no_checks (GCObject *obj, SgenGrayQueue *queue)
+ 	/* set the forwarding pointer */
+ 	SGEN_FORWARD_OBJECT (obj, destination);
+ 
+-	if (has_references) {
++	/*
++	 * Objects of collectible classes must be enqueued for scanning even when their
++	 * descriptor has no reference slots: the scan is what reports the vtable's class
++	 * object (sgen-scan-object.h) and thereby keeps the class's LoaderAllocator alive
++	 * while instances exist. The in-place major mark path (MS_MARK_OBJECT_AND_ENQUEUE)
++	 * already does this; without the same treatment here, a pointer-free instance that
++	 * is promoted during the collection that decides the LoaderAllocator's liveness
++	 * fails to root it. Non-collectible vtables have no class object, so this is a
++	 * single NULL check for them.
++	 */
++	if (has_references || sgen_vtable_has_class_obj (vt)) {
+ 		SGEN_LOG (9, "Enqueuing gray object %p (%s)", destination, sgen_client_vtable_get_name (vt));
+ 		GRAY_OBJECT_ENQUEUE_SERIAL (queue, (GCObject *)destination, sgen_vtable_get_descriptor (vt));
+ 	}
+@@ -119,7 +129,8 @@ copy_object_no_checks_par (GCObject *obj, SgenGrayQueue *queue)
+ 
+ 		if (destination == final_destination) {
+ 			/* In a racing case, only the worker that allocated the object enqueues it */
+-			if (has_references) {
++			/* Collectible classes: enqueue pointer-free objects too, see copy_object_no_checks. */
++			if (has_references || sgen_vtable_has_class_obj (vt)) {
+ 				SGEN_LOG (9, "Enqueuing gray object %p (%s)", destination, sgen_client_vtable_get_name (vt));
+ 				GRAY_OBJECT_ENQUEUE_PARALLEL (queue, (GCObject *)destination, sgen_vtable_get_descriptor (vt));
+ 			}
+diff --git a/src/mono/mono/sgen/sgen-los.c b/src/mono/mono/sgen/sgen-los.c
+index e72f5d421..281c4456e 100644
+--- a/src/mono/mono/sgen/sgen-los.c
++++ b/src/mono/mono/sgen/sgen-los.c
+@@ -886,7 +886,12 @@ sgen_los_pin_objects (SgenGrayQueue *gray_queue, gboolean finish_concurrent_mode
+ 				continue;
+ 			}
+ 			sgen_los_pin_object (obj->data);
+-			if (SGEN_OBJECT_HAS_REFERENCES (obj->data))
++			/*
++			 * Collectible classes: enqueue pointer-free LOS objects too, so the scan
++			 * reports the vtable's class object and keeps the class's LoaderAllocator
++			 * alive (see the LOS branch in sgen-marksweep-drain-gray-stack.h).
++			 */
++			if (SGEN_OBJECT_HAS_REFERENCES (obj->data) || sgen_vtable_has_class_obj (SGEN_LOAD_VTABLE (obj->data)))
+ 				GRAY_OBJECT_ENQUEUE_SERIAL (gray_queue, obj->data, sgen_obj_get_descriptor ((GCObject*)obj->data));
+ 			sgen_pin_stats_register_object (obj->data, GENERATION_OLD);
+ 			SGEN_LOG (6, "Marked large object %p (%s) size: %lu from roots", obj->data,
+diff --git a/src/mono/mono/sgen/sgen-marksweep-drain-gray-stack.h b/src/mono/mono/sgen/sgen-marksweep-drain-gray-stack.h
+index f926ee6d3..a745d3402 100644
+--- a/src/mono/mono/sgen/sgen-marksweep-drain-gray-stack.h
++++ b/src/mono/mono/sgen/sgen-marksweep-drain-gray-stack.h
+@@ -205,7 +205,14 @@ COPY_OR_MARK_FUNCTION_NAME (GCObject **ptr, GCObject *obj, SgenGrayQueue *queue)
+ 
+ 			if (first) {
+ 				sgen_binary_protocol_pin (obj, (gpointer)SGEN_LOAD_VTABLE (obj), sgen_safe_object_get_size (obj));
+-				if (SGEN_OBJECT_HAS_REFERENCES (obj))
++				/*
++				 * Large objects of collectible classes must be enqueued for scanning even
++				 * when pointer-free: the scan reports the vtable's class object
++				 * (sgen-scan-object.h), which is what keeps the class's LoaderAllocator
++				 * alive while instances exist — LOS objects are never marked through
++				 * MS_MARK_OBJECT_AND_ENQUEUE, so this branch is their only chance.
++				 */
++				if (SGEN_OBJECT_HAS_REFERENCES (obj) || sgen_vtable_has_class_obj (SGEN_LOAD_VTABLE (obj)))
+ #ifdef COPY_OR_MARK_PARALLEL
+ 					GRAY_OBJECT_ENQUEUE_PARALLEL (queue, obj, desc);
+ #else
 -- 
 2.43.0
 

--- a/patches/0011-add-in-process-forced-native-unload-lifecycle-tests.patch
+++ b/patches/0011-add-in-process-forced-native-unload-lifecycle-tests.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nick Randolph <noreply@platform.uno>
-Date: Fri, 31 Jul 2026 00:00:00 +0000
+Date: Fri, 7 Aug 2026 00:00:00 +0000
 Subject: [PATCH] test: in-process lifecycle tests for host-triggered native
  ALC unload
 
@@ -216,19 +216,47 @@ Round 10 (review follow-up):
   collectible — the exact condemned window the enumeration regression
   needs, and the metadata-level shape that survives the primary in the
   CI-observed abort.
+
+Round 11 (pointer-free witness regression):
+
+  * ForcedUnload_RootedPointerFreeObjects_BlockNativeFree: regression
+    for the sgen witness fix in patch 0009 round 11 (pointer-free
+    instances of collectible classes must keep their LoaderAllocator
+    witness alive in every scan path, not only the in-place major mark
+    macro). New pointer-free probe types in the test assembly:
+    PointerFreeTestClass (no reference fields) and PointerFreeElement
+    (16-byte struct; a 4096-element array is 64 KiB, above
+    SGEN_MAX_SMALL_OBJ_SIZE = 8000 bytes, so the array probe lives in
+    the large object space). Phase 1 roots the LOS array across the
+    force — pre-fix the array never rooted the witness at any
+    collection (the LOS mark/pin enqueues were reference-gated), so
+    once the loader frame's stale interpreter slots were scrubbed by
+    the per-attempt deep-invoke forces the witness died and the force
+    returned Completed while the array was still rooted: the
+    deterministic red assertion, after which later collections crash
+    on the freed vtable with the downstream-observed
+    "should not be reached" at sgen-scan-object.h:93. Phase 2 roots a
+    small pointer-free instance (the copy/promotion enqueue). Both
+    phases assert NotQuiescent on EVERY force attempt while the probe
+    is rooted, probe usability through the collectible vtable after
+    refused forces, Completed (and idempotent Completed) only after
+    release, probe reclaimability, and clean collections afterwards.
+    On the dark legs (flag off, or threads-enabled runtime) they
+    assert the Rejected surface with the probe untouched. Always-run
+    [Fact]; added to the CI sentinel's required-tests list.
 ---
- .../tests/ForcedNativeUnloadTests.cs          | 1308 +++++++++++++++++
- .../TestClass.cs                              |   37 +
+ .../tests/ForcedNativeUnloadTests.cs          | 1456 +++++++++++++++++
+ .../TestClass.cs                              |   61 +
  .../tests/System.Runtime.Loader.Tests.csproj  |    1 +
- 3 files changed, 1346 insertions(+)
+ 3 files changed, 1518 insertions(+)
  create mode 100644 src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 
 diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 new file mode 100644
-index 000000000..6eae223ba
+index 000000000..9413046a7
 --- /dev/null
 +++ b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
-@@ -0,0 +1,1308 @@
+@@ -0,0 +1,1456 @@
 +// Licensed to the .NET Foundation under one or more agreements.
 +// The .NET Foundation licenses this file to you under the MIT license.
 +
@@ -276,6 +304,13 @@ index 000000000..6eae223ba
 +        private const string TestAssembly = "System.Runtime.Loader.Test.Assembly";
 +        private const string TestClassName = "System.Runtime.Loader.Tests.TestClass";
 +        private const string RehashProbeClassName = "System.Runtime.Loader.Tests.RehashProbeClass";
++        private const string PointerFreeClassName = "System.Runtime.Loader.Tests.PointerFreeTestClass";
++        private const string PointerFreeElementName = "System.Runtime.Loader.Tests.PointerFreeElement";
++
++        // 4096 x 16-byte PointerFreeElement = 64 KiB, comfortably above sgen's small-object
++        // limit (SGEN_MAX_SMALL_OBJ_SIZE, 8000 bytes), so the array probe is a large (LOS)
++        // object — the LOS mark/pin paths never go through the small-object major mark macro.
++        private const int PointerFreeArrayLength = 4096;
 +
 +        // Outcome codes; MUST match AssemblyLoadContext.ForceNativeUnloadResult and the native
 +        // ves_icall_..._InternalForceNativeUnload return codes.
@@ -485,6 +520,48 @@ index 000000000..6eae223ba
 +            }
 +
 +            RunRootedCrossGenericProtocol();
++        }
++
++        /// <summary>
++        /// Pointer-free instances must block the forced native free (sgen witness regression).
++        ///
++        /// The quiescence gate reads each memory manager's LoaderAllocator weak-handle target,
++        /// and the LoaderAllocator is kept alive PER SCAN: every scanned object of a collectible
++        /// class reports its vtable's class object (sgen-scan-object.h). An object whose GC
++        /// descriptor has no reference slots is only enqueued for scanning where the enqueue
++        /// condition is collectible-aware. The in-place major mark macro
++        /// (MS_MARK_OBJECT_AND_ENQUEUE) is; before the fix, the copy/promotion path
++        /// (copy_object_no_checks) and the large-object mark/pin paths (the LOS branch of the
++        /// major gray-stack drain, and sgen_los_pin_objects) were not — they enqueued only when
++        /// the descriptor had references. A live pointer-free LOS array therefore NEVER rooted
++        /// its witness: the gate observed a dead witness while the array was still reachable,
++        /// the force Completed, the array's vtable was freed with its manager, and the next
++        /// collection that marked the array read a garbage descriptor through the dangling
++        /// vtable — crashing on the descriptor switch's g_assert_not_reached in
++        /// sgen-scan-object.h. A small pointer-free instance has the same exposure in the
++        /// collection that promotes it out of the nursery.
++        ///
++        /// Phase 1 roots a large pointer-free struct array (LOS mark paths; the deterministic
++        /// pre-fix red: within a few scrubbed-frame force attempts the witness died and the
++        /// force returned Completed while the array was rooted). Phase 2 roots a small
++        /// pointer-free instance (copy/promotion path; protocol coverage). In both phases the
++        /// force must report NotQuiescent on EVERY attempt while the probe is rooted, the probe
++        /// must stay fully usable, and only after the probe is released may the force Complete
++        /// — after which collections stay clean and the probe is reclaimable.
++        /// </summary>
++        [Fact]
++        public void ForcedUnload_RootedPointerFreeObjects_BlockNativeFree()
++        {
++            if (BridgeMissing())
++            {
++                return;
++            }
++
++            // Phase 1 — the deterministic regression: a rooted LARGE pointer-free array (LOS).
++            RunPointerFreeWitnessProtocol(losArray: true);
++
++            // Phase 2 — the small-object promotion path (copy_object_no_checks).
++            RunPointerFreeWitnessProtocol(losArray: false);
 +        }
 +
 +        [Fact]
@@ -1314,6 +1391,105 @@ index 000000000..6eae223ba
 +            GC.KeepAlive(contextB);
 +        }
 +
++        // One pointer-free witness phase (see ForcedUnload_RootedPointerFreeObjects_BlockNativeFree).
++        // The probe is the ONLY intentional root into the collectible ALC: every other collectible
++        // reference (assembly, Type wrappers, creation temporaries) is confined to the loader
++        // helper's frame, whose stale interpreter slots the deep MethodInfo.Invoke trees of the
++        // per-attempt forces scrub between collections — the same proven mechanism every other
++        // test here relies on (see ForceUntilCompleted and the round-10 notes). Pre-fix, phase 1's
++        // LOS array never rooted the witness at any collection, so once those slots were scrubbed
++        // the witness died and a force returned Completed while the array was still rooted — the
++        // red assertion below.
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static void RunPointerFreeWitnessProtocol(bool losArray)
++        {
++            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
++            var weakProbe = new WeakReference[1];
++            object[] rooted = LoadUnloadReturningRootedPointerFreeProbe(context, losArray, weakProbe);
++
++            if (!ProtocolActive)
++            {
++                // Opt-in off or threads-enabled runtime: rejected regardless of roots, nothing
++                // freed, the probe untouched.
++                GcQuiesce();
++                Assert.Equal(Rejected, Force(context));
++                AssertPointerFreeProbeUsable(rooted, losArray);
++                GC.KeepAlive(rooted);
++                return;
++            }
++
++            // While the pointer-free probe is rooted, EVERY force must report NotQuiescent: the
++            // probe's class-object report is the only thing keeping the witness alive, across
++            // enough collect+force cycles that the loader frame's stale slots are long gone.
++            for (int attempt = 0; attempt < 10; attempt++)
++            {
++                GcQuiesce();
++                Assert.Equal(NotQuiescent, Force(context));
++            }
++
++            // Nothing was freed: the probe stays fully usable through its collectible vtable.
++            AssertPointerFreeProbeUsable(rooted, losArray);
++            Assert.Equal(NotQuiescent, Force(context));
++
++            // Release the probe; the same force must now complete and stay an idempotent no-op.
++            GC.KeepAlive(rooted);
++            rooted = null;
++            Assert.Equal(Completed, ForceUntilCompleted(context, 20));
++            Assert.Equal(Completed, Force(context));
++
++            // Post-teardown hygiene: the released probe is reclaimable, and further collections
++            // over the survivors are clean (no dangling-vtable scans).
++            CollectAndAssertDead(weakProbe);
++            GcQuiesce();
++        }
++
++        // Loads the assembly, creates ONE pointer-free probe (a large PointerFreeElement[] in
++        // LOS, or a small PointerFreeTestClass instance in the nursery), unloads, and returns
++        // only the probe boxed in a default-ALC object[] — so no ALC-typed local, wrapper or
++        // temporary survives in the caller's frame. weakProbe[0] observes the probe's death
++        // after release.
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static object[] LoadUnloadReturningRootedPointerFreeProbe(
++            AssemblyLoadContext context, bool losArray, WeakReference[] weakProbe)
++        {
++            Assembly asm = context.LoadFromAssemblyName(new AssemblyName(TestAssembly));
++            object probe;
++            if (losArray)
++            {
++                Type elementType = asm.GetType(PointerFreeElementName, throwOnError: true);
++                probe = Array.CreateInstance(elementType, PointerFreeArrayLength);
++            }
++            else
++            {
++                Type classType = asm.GetType(PointerFreeClassName, throwOnError: true);
++                probe = Activator.CreateInstance(classType);
++            }
++
++            weakProbe[0] = new WeakReference(probe);
++            context.Unload();
++            return new object[] { probe };
++        }
++
++        // Usability probes for the rooted pointer-free object. GetType() goes through the
++        // (collectible) vtable, so this doubles as a liveness check of the probe's runtime
++        // structures after a refused force. Runs in its own frame: the RuntimeType wrappers it
++        // materializes root the witness while alive, and must never occupy the caller's slots
++        // across the release+force below (the caller's deep-invoke forces scrub this frame's
++        // stale region, as everywhere else in this suite).
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static void AssertPointerFreeProbeUsable(object[] rooted, bool losArray)
++        {
++            if (losArray)
++            {
++                Assert.Equal("PointerFreeElement[]", rooted[0].GetType().Name);
++                Assert.Equal(PointerFreeArrayLength, ((Array)rooted[0]).Length);
++            }
++            else
++            {
++                Assert.Equal("PointerFreeTestClass", rooted[0].GetType().Name);
++            }
++        }
++
 +        // Object-wide tombstone: after a Completed force the stale native ALC pointer must never
 +        // reach an icall again. Every managed consumer funnels through the NativeALC getter, so an
 +        // ordinary API call (the LoadFromAssemblyName -> RuntimeAssembly.InternalLoad path has no
@@ -1538,13 +1714,37 @@ index 000000000..6eae223ba
 +    }
 +}
 diff --git a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs
-index 4a54cb27b..5cad40171 100644
+index 4a54cb27b..7d3bb5ebe 100644
 --- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs
 +++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Test.Assembly/TestClass.cs
-@@ -43,4 +43,41 @@ public class GenericTestClass<T>
+@@ -43,4 +43,65 @@ public class GenericTestClass<T>
          // Allow to store a static reference (either an instance of the ALC or an instance outside of it)
          public static T StaticObjectRef;
      }
++
++    // Pointer-free witness probes for the forced-native-unload lifecycle tests. Instances of
++    // PointerFreeTestClass, and arrays of PointerFreeElement, have GC descriptors with NO
++    // reference slots, so the reference-driven scan never visits them; the only thing that
++    // keeps their collectible LoaderAllocator witness alive is the per-scan class-object
++    // report, which every mark/copy/pin path must therefore perform even for objects it will
++    // never scan for references. The lifecycle tests root these across a forced unload: the
++    // force must stay NotQuiescent for as long as either probe is alive.
++    public class PointerFreeTestClass
++    {
++        public int IntValue;
++        public long LongValue;
++        public double DoubleValue;
++    }
++
++    // Element type for the large pointer-free array probe: 16 bytes per element, so a
++    // 4096-element array is 64 KiB — comfortably above sgen's small-object limit (8000
++    // bytes), forcing the array into the large object space, whose mark/pin paths never go
++    // through the small-object major mark macro.
++    public struct PointerFreeElement
++    {
++        public long A;
++        public long B;
++    }
 +
 +    // Rehash-boundary probe for the collectible reflection caches. Reflecting over ALL declared
 +    // members of this type inserts each MethodInfo/ConstructorInfo/FieldInfo into the owning

--- a/scripts/check-loader-results.sh
+++ b/scripts/check-loader-results.sh
@@ -63,6 +63,7 @@ ForcedUnload_ScoutFinalizerPopulation_Plateaus
 ReflectionHashInit_UnderGcPressure_StaysCoherent_AndHolderHandlesDoNotLeak
 ReflectionOverManyMembers_CrossesWeakRefobjectRehashBoundary
 GlobalAssemblyEnumeration_SkipsCondemnedAssembly_WithoutAbortOrResurrection
+ForcedUnload_RootedPointerFreeObjects_BlockNativeFree
 "
 if [ "$mode" = "mt" ]; then
   # The threads-enabled rejection test is [ConditionalFact(IsThreadingSupported)]: it self-skips


### PR DESCRIPTION
Fixes #169

### What

A downstream host loading previewed apps into collectible AssemblyLoadContexts on browser-wasm (flag on, single-threaded, interpreter) hit a fatal GC assertion — `* Assertion: should not be reached at .../sgen/sgen-scan-object.h:93` — during a collection after forced-unload cycles. That line is the upstream descriptor-switch `default: g_assert_not_reached ()`, reachable only through a **dangling vtable** (freed memory holds an aligned pointer whose low three bits are `000`, so `desc & DESC_TYPE_MASK == 0`).

### Root cause

The quiescence gate trusts the LoaderAllocator weak-handle witness, which is kept alive **per scan**: every scanned object of a collectible class reports its vtable's class object (`sgen-scan-object.h`'s trailing `HANDLE_PTR` block). But pointer-free objects are only enqueued for scanning where the enqueue condition is collectible-aware. Upstream made the in-place major mark macros aware (`MS_MARK_OBJECT_AND_ENQUEUE[_PAR]`), but not:

- `copy_object_no_checks` / `copy_object_no_checks_par` (`sgen-copy-object.h`) — every nursery promotion/evacuation copy;
- the LOS branch of the major gray-stack drain (`sgen-marksweep-drain-gray-stack.h`);
- `sgen_los_pin_objects` (`sgen-los.c`).

A live pointer-free LOS array of an unloadable value type never roots its witness at any major collection (a small pointer-free instance has the same exposure in the collection that promotes it), so the witness dies while instances are still live, the force Completes, `mono_alc_cleanup` frees the vtables, and the next collection that marks a surviving instance crashes on the garbage descriptor. Upstream never reaches this state because its teardown chain is disabled — the forced free makes witness completeness load-bearing. The fork's existing lifecycle tests stayed green because every probe they root carries references.

### Fix (patch 0009, round 11)

Make the three remaining enqueue conditions collectible-aware, identical to `MS_MARK_OBJECT_AND_ENQUEUE`: `has_references || sgen_vtable_has_class_obj (vt)`. All other gray-stack enqueue sites in the applied tree (nursery pin queue, late OOM pin) already enqueue unconditionally; scanning a pointer-free descriptor is a no-op switch case followed by the class-object report, so the change is well-defined for every descriptor type.

**Safety:** the witness now lives strictly longer — forces report `NotQuiescent` until pointer-free instances are released instead of Completing against live memory; nothing is ever reported through a freed pointer. Cost is one NULL field check per copied/pinned pointer-free object (the check the major mark macro already pays); with the flag off every vtable has a NULL `loader_alloc` and behaviour is unchanged.

### Regression test (patch 0011, round 11)

`ForcedUnload_RootedPointerFreeObjects_BlockNativeFree`, required by the CI sentinel on every leg:

- **Phase 1 (deterministic pre-fix red):** roots a 4096-element `PointerFreeElement[]` (64 KiB, above `SGEN_MAX_SMALL_OBJ_SIZE` = 8000 → LOS). Pre-fix the witness died once the loader frame's stale interpreter slots were scrubbed and the force returned `Completed` while the array was rooted; later collections then crash on the freed vtable with the downstream-observed assertion.
- **Phase 2:** roots a small `PointerFreeTestClass` instance (copy/promotion path).
- Both phases assert `NotQuiescent` on **every** force attempt while the probe is rooted, probe usability through the collectible vtable after refused forces, `Completed` (and idempotent `Completed`) only after release, probe reclaimability, and clean collections afterwards. Dark legs assert the `Rejected` surface with the probe untouched.

### Patch discipline

- Patches 0001–0011 applied onto the pin (`081d220c0a`) in a scratch tree; edits made in-tree; 0009/0011 regenerated wholesale via `git format-patch` from real commits (no hand-edited hunks). 0001–0008 and 0010 are untouched.
- Fresh-checkout validation: every patch in sorted order passes `git apply --check` both plain and with `--whitespace=fix`, and the fully applied tree is **byte-identical** to the edited source tree (`git diff --quiet` clean).
- CI (`test_loader_wasm` + `test_loader_wasm_mt` + `ci_ok`) is the compile/validation gate for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
