### PR TITLE
fix(alc): GC-driven scout completion so a refused forced unload cannot strand the context

### DIFF
--- a/patches/0013-gc-driven-scout-completion-for-forced-alc-unload.patch
+++ b/patches/0013-gc-driven-scout-completion-for-forced-alc-unload.patch
@@ -43,20 +43,32 @@ CoreCLR LoaderAllocatorScout design:
     plain GC now reclaims the managed ALC with no host retry. If the
     set is not yet fully dead the scout re-registers for finalization
     (the pre-existing managed retry loop) and tries again next GC.
-  * Tombstone, not free: the scout-driven path keeps the tiny
-    MonoAssemblyLoadContext struct alive with a new native_tombstoned
-    flag (loader-internals.h) instead of g_free-ing it, because a host
-    may still hold the managed context and legitimately retry
-    ForceNativeUnload later -- that retry carries the raw native
-    pointer, so freeing the struct would be a use-after-free. The
-    forced icall answers a tombstoned ALC with an idempotent Completed
-    (before its own quiescence walk), after which the managed wrapper
-    latches its terminal claim and zeroes the pointer exactly as if it
-    had performed the teardown. Managed load APIs were already rejected
-    from the moment Unload() was initiated, so nothing else can carry
-    the stale pointer into native code. The residual is ~one hundred
-    bytes per context, only on the scout-completed path, and bounded by
-    it (a Completed forced attempt still frees the struct as before).
+  * Tombstone, then reclaim on retry: the scout-driven path keeps the
+    tiny MonoAssemblyLoadContext struct alive with a new
+    native_tombstoned flag (loader-internals.h) instead of g_free-ing
+    it, because a host may still hold the managed context and
+    legitimately retry ForceNativeUnload later -- that retry carries
+    the raw native pointer, so freeing the struct eagerly would be a
+    use-after-free. The forced icall answers a tombstoned ALC with an
+    idempotent Completed (before its own quiescence walk) AND frees the
+    struct right there: that retry is provably the LAST carrier of the
+    pointer -- the cleanup already released every other native
+    reference (global-list membership, images, managers, name,
+    gchandle), and on Completed the managed wrapper zeroes its pointer
+    and latches the terminal claim, whose CAS short-circuits every
+    later call before it can reach the icall. Managed load APIs were
+    already rejected from the moment Unload() was initiated, so nothing
+    else can carry the stale pointer into native code. Only hosts that
+    NEVER retry keep the ~one-hundred-byte struct per unloaded context
+    -- the documented, bounded residual of the scout-completed path (a
+    Completed forced attempt still frees everything at once, as
+    before).
+  * No zero-witness hole: every opted-in collectible ALC eagerly
+    materialises its primary LoaderAllocator -- and therefore a scout
+    and a weak witness -- at creation (mono_alc_init calls
+    mono_mem_manager_get_loader_alloc on the primary manager), so an
+    unloading ALC with no scout to drive the completion is
+    unconstructible under the opt-in.
   * Ordering safety is inherited from the existing retired-scout
     registry: scouts whose manager was freed by any teardown (forced or
     scout-driven -- mono_alc_cleanup registers every materialised
@@ -71,36 +83,66 @@ CoreCLR LoaderAllocatorScout design:
     (monotonic), so the tests can prove the reclaim went through the
     scout path rather than passing vacuously -- under the opt-in the
     strong handle makes ALC death impossible any other way, and the
-    stat pins it explicitly.
+    stat pins it explicitly. Kind 8 is a gauge of collectible,
+    unloading, not-yet-torn-down ALCs: a witness that never dies would
+    otherwise be observable only as silent scout re-registration,
+    indistinguishable from the pre-fix strand; the tests assert the
+    gauge drains back to 0 after every cycle.
 
-New lifecycle regressions (red on the previous runtime for the flag-on
-leg, exactly like the field failure; green flag-off/threads):
+Alternatives considered and rejected:
+
+  (a) Not installing the strong Prepare handle under the opt-in would
+      let the managed ALC die mid-unloading-window, but that handle is
+      what Assembly.LoadContext (GetLoadContextForAssembly returns
+      alc->gchandle) and the resolve-event dispatch (assembly.c takes
+      the gchandle target to deliver Resolving callbacks) rely on
+      during the window -- dropping it changes observable semantics
+      for any assembly still alive while its ALC unloads.
+  (b) Releasing the strong handle on the NotQuiescent early-out frees
+      the managed side but permanently strands the NATIVE side: the
+      managers and images can only be freed by the quiescence-gated
+      cleanup, and once the managed ALC is collected no forced retry
+      can ever be issued -- the per-cycle leak merely changes shape.
+  (c) Documenting a host-must-retry contract pushes the runtime's
+      correctness obligation onto every host and turns a missed retry
+      into an unbounded leak; the field failure IS that contract being
+      missed once per cycle.
+  GC-driven completion has none of these costs: window semantics are
+  preserved (the handle stays strong until the teardown), both managed
+  and native sides are reclaimed, and no host cooperation is required.
+
+New lifecycle tests:
 
   * ForcedUnload_SingleNotQuiescentAttempt_ThenDroppedRoots_DoesNotStrandAlc
     -- the reported shape: one refused attempt on a genuinely rooted
     context, roots dropped, no retry; plain GC must reclaim the context
-    and kind-7 must advance.
+    and kind-7 must advance by exactly one. RED on the previous runtime
+    for the flag-on leg, exactly like the field failure; green
+    flag-off/threads.
   * Unload_DroppedRootsWithoutAnyForcedAttempt_AlcIsCollectible -- the
-    purest contract: no attempt at all; same reclaim, same kind-7
-    proof.
-  * ForcedUnload_RetryAfterRootsDropped_CompletesWithZeroResidual -- a
-    host that does retry must observe Completed whether its retry or
-    the scout completion performed the teardown (tombstone idempotence)
-    and the scout residual must drain to zero.
+    purest contract: no attempt at all; same reclaim, same exact kind-7
+    proof. RED on the previous runtime for the flag-on leg.
+  * ForcedUnload_RetryAfterRootsDropped_CompletesWithZeroResidual --
+    NOT a strand red (it also passes pre-fix): it deterministically
+    covers the tombstone-retry branch (the UAF guard) by pumping GC
+    until kind-7 advances BEFORE retrying, then asserts the retry
+    Completes, that a further call is answered by the managed
+    terminal-claim latch, and that the scout registry and the
+    pending-unloads gauge drain to zero.
 
 Refs https://github.com/unoplatform/Uno.DotnetRuntime.WebAssembly/issues/169.
 ---
- .../tests/ForcedNativeUnloadTests.cs          | 225 +++++++++++++++++-
- .../Loader/AssemblyLoadContext.Mono.cs        |  14 +-
- .../mono/metadata/assembly-load-context.c     | 185 ++++++++++----
+ .../tests/ForcedNativeUnloadTests.cs          | 262 +++++++++++++++++-
+ .../Loader/AssemblyLoadContext.Mono.cs        |  18 +-
+ .../mono/metadata/assembly-load-context.c     | 218 ++++++++++++---
  src/mono/mono/metadata/loader-internals.h     |   7 +
- 4 files changed, 384 insertions(+), 47 deletions(-)
+ 4 files changed, 459 insertions(+), 46 deletions(-)
 
 diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
-index 60708a1b5..c1063c8e3 100644
+index 60708a1b5..c79d99543 100644
 --- a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 +++ b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
-@@ -78,6 +78,10 @@ public class ForcedNativeUnloadTests
+@@ -78,6 +78,13 @@ public class ForcedNativeUnloadTests
          // manager's LoaderAllocator; mono_weak_hash_table_dead_lookup_count). Unconditional
          // shared-runtime code, like kinds 2/3/5.
          private const int WeakTableDeadLookupCount = 6;
@@ -108,10 +150,13 @@ index 60708a1b5..c1063c8e3 100644
 +        // LoaderAllocator witness ran the quiescence-gated teardown itself; see
 +        // LoaderAllocatorScout_Destroy). Behind the DISABLE_THREADS gate like kinds 0/1.
 +        private const int ScoutCompletedTeardownCount = 7;
++        // GAUGE (not monotonic): collectible, unloading ALCs whose teardown has not completed
++        // yet. Makes a never-dying witness visible; must drain back to 0 after every cycle.
++        private const int PendingUnloadsGauge = 8;
  
          private static readonly MethodInfo s_forceNativeUnload = typeof(AssemblyLoadContext)
              .GetMethod("ForceNativeUnload", BindingFlags.NonPublic | BindingFlags.Instance);
-@@ -269,6 +273,116 @@ public async Task ForcedUnload_OnlyCompletesOnceQuiescent()
+@@ -269,6 +276,150 @@ public async Task ForcedUnload_OnlyCompletesOnceQuiescent()
              }
          }
  
@@ -150,9 +195,10 @@ index 60708a1b5..c1063c8e3 100644
 +
 +            if (ProtocolActive)
 +            {
-+                Assert.True(ScoutStats(ScoutCompletedTeardownCount) > scoutCompletionsBefore,
-+                    "the reclaim must have been performed by the GC-driven scout completion " +
-+                    $"(kind-7 before={scoutCompletionsBefore} after={ScoutStats(ScoutCompletedTeardownCount)}).");
++                // Exactly one ALC was pending in this test and every earlier test drove its
++                // contexts terminal, so the scout completion advanced by exactly one.
++                Assert.Equal(scoutCompletionsBefore + 1, ScoutStats(ScoutCompletedTeardownCount));
++                Assert.Equal(0, ScoutStats(PendingUnloadsGauge));
 +            }
 +        }
 +
@@ -181,18 +227,26 @@ index 60708a1b5..c1063c8e3 100644
 +
 +            if (ProtocolActive)
 +            {
-+                Assert.True(ScoutStats(ScoutCompletedTeardownCount) > scoutCompletionsBefore,
-+                    "the reclaim must have been performed by the GC-driven scout completion " +
-+                    $"(kind-7 before={scoutCompletionsBefore} after={ScoutStats(ScoutCompletedTeardownCount)}).");
++                // Exactly one ALC was pending in this test and every earlier test drove its
++                // contexts terminal, so the scout completion advanced by exactly one.
++                Assert.Equal(scoutCompletionsBefore + 1, ScoutStats(ScoutCompletedTeardownCount));
++                Assert.Equal(0, ScoutStats(PendingUnloadsGauge));
 +            }
 +        }
 +
 +        /// <summary>
-+        /// A host that DOES retry after dropping its roots must still observe Completed — either
-+        /// because its retry performs the teardown, or because the scout completion beat it there
-+        /// and the retry reports the already-completed state idempotently (the native struct is
-+        /// kept as a tombstone precisely so this retry cannot dereference freed storage). The
-+        /// scout residual must also fully drain.
++        /// A host that DOES retry after dropping its roots must observe Completed — and this
++        /// test makes the retry deterministically exercise the native tombstone branch, the
++        /// use-after-free guard: it first pumps GC until the scout completion has provably
++        /// performed the teardown (exact kind-7 advance) and only then retries. Without that
++        /// ordering the retry races the scheduled scout finalizer, and whenever the retry won
++        /// it would complete through the ordinary quiescence walk, leaving the tombstone branch
++        /// permanently uncovered while staying green. The tombstoned retry also reclaims the
++        /// struct; a further call is answered by the managed terminal-claim latch and never
++        /// reaches native code at all. "Zero residual" means the scout registry drains and the
++        /// pending-unloads gauge returns to 0 — the struct itself was freed by the retry.
++        /// (Unlike the two strand regressions above, this test also passes on the pre-fix
++        /// runtime: it guards the retry contract and the tombstone coverage, not the strand.)
 +        /// </summary>
 +        [Fact]
 +        public async Task ForcedUnload_RetryAfterRootsDropped_CompletesWithZeroResidual()
@@ -204,16 +258,22 @@ index 60708a1b5..c1063c8e3 100644
 +
 +            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
 +            var weakRef = new WeakReference(context);
++            int scoutCompletionsBefore = ProtocolActive ? ScoutStats(ScoutCompletedTeardownCount) : 0;
 +            FirstAttemptOnRootedContext(context);
 +
 +            if (ProtocolActive)
 +            {
-+                // Second attempt after the rooted state died: must reach Completed no matter
-+                // whether this attempt or the scout completion performs the teardown.
-+                Assert.Equal(Completed, await ForceUntilCompletedAsync(context, 10));
-+                // Idempotence holds across the tombstone path too.
++                // Deterministic ordering: wait until the scout completion performed the
++                // teardown, so the retry below provably lands on native_tombstoned.
++                await PumpUntilScoutCompletionAsync(scoutCompletionsBefore);
++
++                // The retry hits the tombstone branch: idempotent Completed, struct reclaimed.
++                Assert.Equal(Completed, Force(context));
++                // A further call never reaches native: the managed terminal-claim latch
++                // (prior == 2) answers before the icall.
 +                Assert.Equal(Completed, Force(context));
 +                await DrainRetiredScoutsAsync();
++                Assert.Equal(0, ScoutStats(PendingUnloadsGauge));
 +            }
 +            else
 +            {
@@ -225,10 +285,29 @@ index 60708a1b5..c1063c8e3 100644
 +                "a retried forced unload must leave the context reclaimable with zero residual.");
 +        }
 +
++        // Pumps GC and the event-loop finalizer pump until the GC-driven scout completion has
++        // performed exactly one more teardown than `before`. Bounded, and exact: only one ALC
++        // is pending in the calling test and earlier tests drove their contexts terminal.
++        private static async Task PumpUntilScoutCompletionAsync(int before)
++        {
++            for (int attempt = 0; attempt < 20; attempt++)
++            {
++                if (ScoutStats(ScoutCompletedTeardownCount) > before)
++                {
++                    break;
++                }
++
++                GcQuiesce();
++                await Task.Delay(1);
++            }
++
++            Assert.Equal(before + 1, ScoutStats(ScoutCompletedTeardownCount));
++        }
++
          [Fact]
          public async Task ForcedUnload_RootedCrossContextGeneric_BlocksNativeFree()
          {
-@@ -936,6 +1050,29 @@ private static async Task RunRejectedCycles(int cycles)
+@@ -936,6 +1087,29 @@ private static async Task RunRejectedCycles(int cycles)
              }
          }
  
@@ -258,7 +337,7 @@ index 60708a1b5..c1063c8e3 100644
          // Drive GC + finalization until the retired-scout set drains. Counter-based and bounded:
          // each pass collects (queueing/re-queueing any scouts whose LoaderAllocator is dead,
          // including ones that re-registered with FALSE on an earlier pass) and then lets finalizers
-@@ -966,6 +1103,91 @@ private static async Task DrainRetiredScoutsAsync()
+@@ -966,6 +1140,91 @@ private static async Task DrainRetiredScoutsAsync()
              Assert.Equal(0, ScoutStats(RetiredSetSize));
          }
  
@@ -350,7 +429,7 @@ index 60708a1b5..c1063c8e3 100644
          [MethodImpl(MethodImplOptions.NoInlining)]
          private static async Task<WeakReference> LoadExerciseUnloadAndForce()
          {
-@@ -1554,7 +1776,8 @@ private static void Churn(int rounds)
+@@ -1554,7 +1813,8 @@ private static void Churn(int rounds)
          // Holding asm/type/list in THIS frame across the force would keep the primary and
          // shared-generic LoaderAllocator witnesses alive and pin the force at NotQuiescent. Only
          // the ALC object itself lives here, which is safe: the runtime holds a strong handle to
@@ -361,10 +440,10 @@ index 60708a1b5..c1063c8e3 100644
          private static async Task ReflectionHashInitUnderPressureCycle(int seed)
          {
 diff --git a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
-index 88ce94a0c..25ff655e0 100644
+index 88ce94a0c..707d2ec1f 100644
 --- a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
 +++ b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
-@@ -78,6 +78,12 @@ private static void KeepLoaderAllocator()
+@@ -78,6 +78,16 @@ private static void KeepLoaderAllocator()
          // cycles rather than growing by three per reflection-using memory manager. Unlike kinds
          // 0/1 these are available on every build, because the ownership fix they observe is
          // unconditional (not part of the DISABLE_THREADS-gated forced teardown).
@@ -374,10 +453,14 @@ index 88ce94a0c..25ff655e0 100644
 +        // quiescent — see LoaderAllocatorScout_Destroy in assembly-load-context.c). Gated like
 +        // kinds 0/1. Lifecycle tests use it to prove an ALC reclaimed after its host dropped
 +        // every root really went through the scout path rather than a forced attempt.
++        //
++        // Kind 8 is a GAUGE (not monotonic): collectible, unloading ALCs whose teardown has not
++        // completed yet. A witness that never dies is otherwise observable only as silent scout
++        // re-registration; this makes pending unloads visible, and tests assert it drains to 0.
          internal static int GetScoutRetirementStats(int kind) => InternalGetScoutRetirementStats(kind);
  
          [MethodImplAttribute(MethodImplOptions.InternalCall)]
-@@ -119,7 +125,13 @@ internal static int RunJiterpreterTableSelfTest()
+@@ -119,7 +129,13 @@ internal static int RunJiterpreterTableSelfTest()
          // in the native assembly-load-context.c.
          internal enum ForceNativeUnloadResult
          {
@@ -393,7 +476,7 @@ index 88ce94a0c..25ff655e0 100644
              // The managed LoaderAllocator is still rooted (its weak handle target is non-NULL), so
              // freeing now would reclaim live memory. Nothing was freed; the caller should retry
 diff --git a/src/mono/mono/metadata/assembly-load-context.c b/src/mono/mono/metadata/assembly-load-context.c
-index d8eac6e34..0590552c9 100644
+index d8eac6e34..43f1121db 100644
 --- a/src/mono/mono/metadata/assembly-load-context.c
 +++ b/src/mono/mono/metadata/assembly-load-context.c
 @@ -80,6 +80,10 @@ alcs_unlock (void)
@@ -500,7 +583,7 @@ index d8eac6e34..0590552c9 100644
  	 *   1 = NotQuiescent  — managed roots to the ALC still exist; nothing freed, retry later.
  	 *   2 = Rejected      — feature unavailable (threads-enabled build), or null / default /
  	 *                       non-collectible / not-yet-unloading ALC.
-@@ -505,45 +565,19 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
+@@ -505,45 +565,27 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
  		return FORCE_UNLOAD_REJECTED;
  
  	/*
@@ -513,7 +596,13 @@ index d8eac6e34..0590552c9 100644
 -	 * a manager's weak-handle target is non-NULL, managed roots remain and freeing would
 -	 * reclaim live memory. This is exactly the criterion the (disabled)
 -	 * LoaderAllocatorScout uses.
--	 *
++	 * Idempotent completion: the GC-driven scout path (LoaderAllocatorScout_Destroy below)
++	 * may have already torn this ALC down after the host's roots died — a downstream WASM
++	 * host doing repeated collectible-ALC load/unload cycles is not required to keep
++	 * retrying a NotQuiescent attempt for the reclamation to happen. Everything material
++	 * was freed by mono_alc_cleanup then; only this struct remained as the tombstone (see
++	 * native_tombstoned in loader-internals.h), so report Completed.
+ 	 *
 -	 * Every shared/generic memory manager has its OWN LoaderAllocator witness: a live
 -	 * cross-context constructed generic (e.g. an instance whose vtable lives in a shared
 -	 * {default, this} manager) keeps that shared witness alive even after the primary
@@ -523,22 +612,19 @@ index d8eac6e34..0590552c9 100644
 -	 * NotQuiescent so the host retries after another GC rather than losing its single
 -	 * chance. A NULL weak handle means no LoaderAllocator bookkeeping was ever materialised
 -	 * for that manager (no vtable/object of it ever existed), which is safe to free.
-+	 * Idempotent completion: the GC-driven scout path (LoaderAllocatorScout_Destroy below)
-+	 * may have already torn this ALC down after the host's roots died — a downstream WASM
-+	 * host doing repeated collectible-ALC load/unload cycles is not required to keep
-+	 * retrying a NotQuiescent attempt for the reclamation to happen. Everything material
-+	 * was freed by mono_alc_cleanup then; only this struct remains (see native_tombstoned
-+	 * in loader-internals.h), so report Completed without dereferencing anything further.
-+	 * The managed wrapper latches its terminal claim and zeroes its pointer on Completed,
-+	 * exactly as if this call had performed the teardown itself.
++	 * And reclaim the tombstone itself: this retry is provably the LAST carrier of the raw
++	 * struct pointer. The cleanup already released every other native reference (global
++	 * alcs-list membership, images, managers, name, gchandle), and on Completed the managed
++	 * wrapper zeroes its _nativeAssemblyLoadContext and latches the terminal claim, whose
++	 * CAS short-circuits every later ForceNativeUnload call before it can reach this icall.
++	 * Only hosts that NEVER retry keep the ~100-byte struct per unloaded context — the
++	 * documented, bounded residual of the scout-completed path.
  	 */
 -	MonoMemoryManager *primary_mm = alc->memory_manager;
 -	if (primary_mm && primary_mm->loader_allocator_weak_handle &&
 -			mono_gchandle_get_target_internal (primary_mm->loader_allocator_weak_handle) != NULL)
 -		return FORCE_UNLOAD_NOT_QUIESCENT;
-+	if (alc->native_tombstoned)
-+		return FORCE_UNLOAD_COMPLETED;
- 
+-
 -	gboolean witness_live = FALSE;
 -	mono_alc_memory_managers_lock (alc);
 -	for (guint i = 0; i < alc->generic_memory_managers->len; i++) {
@@ -550,14 +636,18 @@ index d8eac6e34..0590552c9 100644
 -			witness_live = TRUE;
 -			break;
 -		}
--	}
++	if (alc->native_tombstoned) {
++		g_free (alc);
++		return FORCE_UNLOAD_COMPLETED;
+ 	}
 -	mono_alc_memory_managers_unlock (alc);
 -	if (witness_live)
++
 +	if (!alc_is_managed_quiescent (alc))
  		return FORCE_UNLOAD_NOT_QUIESCENT;
  
  	mono_alc_free (alc);
-@@ -593,6 +627,12 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+@@ -593,6 +635,19 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
  	 * mono_weak_hash_table_dead_lookup_count). Unconditional like kinds 2/3/5. A lifecycle test
  	 * uses it to prove the global assembly enumeration really took the terminal dead-cache path
  	 * for a condemned assembly (skipping it) instead of passing vacuously.
@@ -567,19 +657,37 @@ index d8eac6e34..0590552c9 100644
 +	 * DISABLE_THREADS gate like kinds 0/1. Lifecycle tests use it to prove an ALC whose host
 +	 * dropped every root without retrying a NotQuiescent forced attempt was really reclaimed
 +	 * by the scout finalizer rather than by a forced attempt.
++	 *
++	 * Kind 8 — GAUGE (not monotonic): collectible, unloading, not-yet-torn-down ALCs still
++	 * on the global list — unloads whose teardown has not completed yet. Behind the
++	 * DISABLE_THREADS gate like kinds 0/1. A witness that never dies would otherwise be
++	 * observable only as silent infinite scout re-registration, indistinguishable from the
++	 * pre-fix strand; this gauge makes it visible, and the lifecycle tests assert it drains
++	 * back to 0 after every cycle.
  	 */
  	if (kind == 2 || kind == 3)
  		return mono_weak_hash_table_key_value_handle_stats (kind - 2);
-@@ -611,6 +651,8 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+@@ -611,6 +666,19 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
  		return retired_scout_terminal_count;
  	case 4:
  		return mono_mem_manager_alc_unload_test_gc_hook_count ();
 +	case 7:
 +		return scout_completed_teardown_count;
++	case 8: {
++		int pending = 0;
++		alcs_lock ();
++		for (GSList *tmp = alcs; tmp; tmp = tmp->next) {
++			MonoAssemblyLoadContext *a = (MonoAssemblyLoadContext *)tmp->data;
++			if (a && a->collectible && a->unloading && !a->native_tombstoned)
++				pending++;
++		}
++		alcs_unlock ();
++		return pending;
++	}
  	default:
  		return -1;
  	}
-@@ -1097,8 +1139,9 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
+@@ -1097,8 +1165,9 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
  {
  #ifdef DISABLE_THREADS
  	/*
@@ -591,7 +699,7 @@ index d8eac6e34..0590552c9 100644
  	 * The consult is a pure pointer-value comparison — the freed manager is NEVER
  	 * dereferenced — and consuming the entry retires exactly one scout: it returns TRUE,
  	 * so the finalizer does not GC.ReRegisterForFinalize and the scout population stays
-@@ -1109,6 +1152,58 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
+@@ -1109,6 +1178,67 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
  		retired_scout_terminal_count++;
  		return TRUE;
  	}
@@ -620,6 +728,12 @@ index d8eac6e34..0590552c9 100644
 +	 * under the MONO_WASM_ENABLE_ALC_UNLOAD opt-in (mono_alc_init), so default consumers
 +	 * never take this branch. The owner scan runs BEFORE mono_alc_cleanup because the
 +	 * cleanup frees this manager (mm->alcs lives in its mempool).
++	 *
++	 * No zero-witness hole: every opted-in collectible ALC eagerly materialises its
++	 * primary LoaderAllocator — and therefore a scout and a weak witness — at creation
++	 * (mono_alc_init calls mono_mem_manager_get_loader_alloc on the primary manager, which
++	 * creates the managed LoaderAllocator/Scout pair and the weak handle), so an unloading
++	 * ALC with no scout to drive this completion is unconstructible under the opt-in.
 +	 */
 +	MonoMemoryManager *mm = (MonoMemoryManager *)native;
 +	MonoAssemblyLoadContext *condemned = NULL;
@@ -640,12 +754,15 @@ index d8eac6e34..0590552c9 100644
 +		 * The cleanup freed this scout's own manager and registered it (with every other
 +		 * materialised manager of the ALC) in the retired registry, so consume the entry
 +		 * now for the terminal outcome instead of waiting for a pointless extra
-+		 * finalization round.
++		 * finalization round. The consume MUST succeed: this scout exists, so its
++		 * manager's LoaderAllocator was materialised (weak handle non-NULL), and the
++		 * cleanup just registered exactly that manager — assert it so a future refactor
++		 * of the registration sites cannot silently reopen a use-after-free window here.
 +		 */
-+		if (retired_scout_targets_consume (native)) {
-+			retired_scout_terminal_count++;
-+			return TRUE;
-+		}
++		gboolean consumed = retired_scout_targets_consume (native);
++		g_assert (consumed);
++		retired_scout_terminal_count++;
++		return TRUE;
 +	}
  #endif
  

--- a/patches/0013-gc-driven-scout-completion-for-forced-alc-unload.patch
+++ b/patches/0013-gc-driven-scout-completion-for-forced-alc-unload.patch
@@ -63,6 +63,27 @@ CoreCLR LoaderAllocatorScout design:
     -- the documented, bounded residual of the scout-completed path (a
     Completed forced attempt still frees everything at once, as
     before).
+  * Torn-down guard at the icall boundary: between the scout
+    completion and a host retry, the surviving managed wrapper still
+    carries the raw native pointer with an idle claim, and the BY-NAME
+    load path (LoadFromAssemblyName ->
+    Assembly/RuntimeAssembly.InternalLoad) reaches the native ALC
+    without any managed VerifyIsAlive gate -- an ordinary load in that
+    window would walk into state mono_alc_cleanup already destroyed
+    (assemblies_lock, loaded_images): a use-after-destroy, not an
+    exception. Every icall that receives the raw pointer (InternalLoad
+    by-name, InternalLoadFile, InternalLoadFromStream) now rejects a
+    native_tombstoned context up front with InvalidOperationException
+    (mono_alc_reject_if_torn_down); reading the flag is safe because
+    the struct is freed only by the claim-gated retry, and the managed
+    NativeALC getter blocks every consumer once that claim is latched.
+    Loads into an unloading-but-not-yet-torn-down context
+    intentionally keep working: the native side is fully functional
+    there, and upstream also services cached by-name resolves during
+    the unloading window (the path/stream entry points
+    VerifyIsAlive-reject there, upstream and here alike), so a blanket
+    managed unloading guard on the by-name path would change
+    contractual behavior default consumers rely on.
   * No zero-witness hole: every opted-in collectible ALC eagerly
     materialises its primary LoaderAllocator -- and therefore a scout
     and a weak witness -- at creation (mono_alc_init calls
@@ -125,21 +146,25 @@ New lifecycle tests:
   * ForcedUnload_RetryAfterRootsDropped_CompletesWithZeroResidual --
     NOT a strand red (it also passes pre-fix): it deterministically
     covers the tombstone-retry branch (the UAF guard) by pumping GC
-    until kind-7 advances BEFORE retrying, then asserts the retry
-    Completes, that a further call is answered by the managed
-    terminal-claim latch, and that the scout registry and the
-    pending-unloads gauge drain to zero.
+    until kind-7 advances BEFORE retrying, asserts an ordinary by-name
+    load in the tombstone window rejects in managed code (on unguarded
+    code that call is a native use-after-destroy, so this leg is red
+    without the icall guard), then asserts the retry Completes, that a
+    further call is answered by the managed terminal-claim latch, and
+    that the scout registry and the pending-unloads gauge drain to
+    zero.
 
 Refs https://github.com/unoplatform/Uno.DotnetRuntime.WebAssembly/issues/169.
 ---
- .../tests/ForcedNativeUnloadTests.cs          | 262 +++++++++++++++++-
+ .../tests/ForcedNativeUnloadTests.cs          | 271 +++++++++++++++++-
  .../Loader/AssemblyLoadContext.Mono.cs        |  18 +-
- .../mono/metadata/assembly-load-context.c     | 218 ++++++++++++---
- src/mono/mono/metadata/loader-internals.h     |   7 +
- 4 files changed, 459 insertions(+), 46 deletions(-)
+ src/mono/mono/metadata/appdomain.c            |   7 +
+ .../mono/metadata/assembly-load-context.c     | 251 +++++++++++++---
+ src/mono/mono/metadata/loader-internals.h     |  13 +
+ 5 files changed, 514 insertions(+), 46 deletions(-)
 
 diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
-index 60708a1b5..c79d99543 100644
+index 60708a1b5..4bc5107b3 100644
 --- a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 +++ b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 @@ -78,6 +78,13 @@ public class ForcedNativeUnloadTests
@@ -156,7 +181,7 @@ index 60708a1b5..c79d99543 100644
  
          private static readonly MethodInfo s_forceNativeUnload = typeof(AssemblyLoadContext)
              .GetMethod("ForceNativeUnload", BindingFlags.NonPublic | BindingFlags.Instance);
-@@ -269,6 +276,150 @@ public async Task ForcedUnload_OnlyCompletesOnceQuiescent()
+@@ -269,6 +276,159 @@ public async Task ForcedUnload_OnlyCompletesOnceQuiescent()
              }
          }
  
@@ -267,6 +292,15 @@ index 60708a1b5..c79d99543 100644
 +                // teardown, so the retry below provably lands on native_tombstoned.
 +                await PumpUntilScoutCompletionAsync(scoutCompletionsBefore);
 +
++                // The tombstone window: the wrapper still carries the raw native pointer and
++                // its claim is idle, so an ordinary load API must reject BEFORE any native
++                // dereference of the destroyed state (assemblies_lock, loaded_images). The
++                // by-name path has no managed VerifyIsAlive gate, so the reject comes from the
++                // native torn-down guard at the icall entry — on unguarded code this call is a
++                // native use-after-destroy (crash), not an exception.
++                Assert.Throws<InvalidOperationException>(
++                    () => context.LoadFromAssemblyName(new AssemblyName(TestAssembly)));
++
 +                // The retry hits the tombstone branch: idempotent Completed, struct reclaimed.
 +                Assert.Equal(Completed, Force(context));
 +                // A further call never reaches native: the managed terminal-claim latch
@@ -307,7 +341,7 @@ index 60708a1b5..c79d99543 100644
          [Fact]
          public async Task ForcedUnload_RootedCrossContextGeneric_BlocksNativeFree()
          {
-@@ -936,6 +1087,29 @@ private static async Task RunRejectedCycles(int cycles)
+@@ -936,6 +1096,29 @@ private static async Task RunRejectedCycles(int cycles)
              }
          }
  
@@ -337,7 +371,7 @@ index 60708a1b5..c79d99543 100644
          // Drive GC + finalization until the retired-scout set drains. Counter-based and bounded:
          // each pass collects (queueing/re-queueing any scouts whose LoaderAllocator is dead,
          // including ones that re-registered with FALSE on an earlier pass) and then lets finalizers
-@@ -966,6 +1140,91 @@ private static async Task DrainRetiredScoutsAsync()
+@@ -966,6 +1149,91 @@ private static async Task DrainRetiredScoutsAsync()
              Assert.Equal(0, ScoutStats(RetiredSetSize));
          }
  
@@ -429,7 +463,7 @@ index 60708a1b5..c79d99543 100644
          [MethodImpl(MethodImplOptions.NoInlining)]
          private static async Task<WeakReference> LoadExerciseUnloadAndForce()
          {
-@@ -1554,7 +1813,8 @@ private static void Churn(int rounds)
+@@ -1554,7 +1822,8 @@ private static void Churn(int rounds)
          // Holding asm/type/list in THIS frame across the force would keep the primary and
          // shared-generic LoaderAllocator witnesses alive and pin the force at NotQuiescent. Only
          // the ALC object itself lives here, which is safe: the runtime holds a strong handle to
@@ -475,8 +509,26 @@ index 88ce94a0c..707d2ec1f 100644
              Completed = 0,
              // The managed LoaderAllocator is still rooted (its weak handle target is non-NULL), so
              // freeing now would reclaim live memory. Nothing was freed; the caller should retry
+diff --git a/src/mono/mono/metadata/appdomain.c b/src/mono/mono/metadata/appdomain.c
+index f0a778910..29a5abbbe 100644
+--- a/src/mono/mono/metadata/appdomain.c
++++ b/src/mono/mono/metadata/appdomain.c
+@@ -781,6 +781,13 @@ ves_icall_System_Reflection_Assembly_InternalLoad (MonoStringHandle name_handle,
+ 		g_assert_not_reached ();
+ 
+ 	g_assert (alc);
++
++	/* By-name loads reach the native ALC without any managed VerifyIsAlive gate (unlike the
++	 * path/stream entry points), so reject a torn-down context here before the request
++	 * touches state mono_alc_cleanup already destroyed. See mono_alc_reject_if_torn_down. */
++	if (mono_alc_reject_if_torn_down (alc, error))
++		goto fail;
++
+ 	mono_assembly_request_prepare_byname (&req, alc);
+ 	req.basedir = NULL;
+ 	/* Everything currently goes through this function, and the postload hook (aka the AppDomain.AssemblyResolve event)
 diff --git a/src/mono/mono/metadata/assembly-load-context.c b/src/mono/mono/metadata/assembly-load-context.c
-index d8eac6e34..43f1121db 100644
+index d8eac6e34..aae388735 100644
 --- a/src/mono/mono/metadata/assembly-load-context.c
 +++ b/src/mono/mono/metadata/assembly-load-context.c
 @@ -80,6 +80,10 @@ alcs_unlock (void)
@@ -687,7 +739,60 @@ index d8eac6e34..43f1121db 100644
  	default:
  		return -1;
  	}
-@@ -1097,8 +1165,9 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
+@@ -768,12 +836,43 @@ leave:
+ 	HANDLE_FUNCTION_RETURN_VAL (ass);
+ }
+ 
++/*
++ * Guard for icalls that receive a raw native ALC pointer from the managed wrapper. After
++ * the GC-driven scout completion tore an ALC down (native_tombstoned), the surviving
++ * managed wrapper still carries the raw pointer and its terminal claim is only latched by
++ * a later ForceNativeUnload retry — so an ordinary load API called in that window would
++ * otherwise walk straight into state mono_alc_cleanup already destroyed (assemblies_lock,
++ * loaded_images, ...): a use-after-destroy, not an exception. Reading the flag here is
++ * safe by construction: the tombstoned struct is freed only by the claim-gated retry, and
++ * once that claim is latched the managed NativeALC getter rejects every consumer before
++ * the pointer can reach an icall again.
++ *
++ * The reject surfaces as InvalidOperationException with the unloading-contract semantics
++ * of the managed entry points (LoadFromAssemblyPath/LoadFromStream VerifyIsAlive-throw the
++ * same for ANY unloading state upstream and here). Loads into an unloading-but-not-yet-
++ * torn-down context intentionally keep working: the native side is fully functional
++ * there, and upstream also services cached by-name resolves during the unloading window —
++ * a blanket managed unloading guard on the by-name path would break exactly that.
++ */
++gboolean
++mono_alc_reject_if_torn_down (MonoAssemblyLoadContext *alc, MonoError *error)
++{
++	if (alc && alc->native_tombstoned) {
++		mono_error_set_invalid_operation (error, "Cannot use a collectible AssemblyLoadContext whose unload has already completed.");
++		return TRUE;
++	}
++	return FALSE;
++}
++
+ MonoReflectionAssemblyHandle
+ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalLoadFile (gpointer alc_ptr, MonoStringHandle fname, MonoStackCrawlMark *stack_mark, MonoError *error)
+ {
+ 	MonoReflectionAssemblyHandle result = MONO_HANDLE_CAST (MonoReflectionAssembly, NULL_HANDLE);
+ 	MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)alc_ptr;
+ 
++	if (mono_alc_reject_if_torn_down (alc, error))
++		goto leave;
++
+ 	MonoAssembly *executing_assembly;
+ 	executing_assembly = mono_runtime_get_caller_from_stack_mark (stack_mark);
+ 	MonoAssembly *ass = mono_alc_load_file (alc, fname, executing_assembly, !mono_alc_is_default (alc), error);
+@@ -823,6 +922,8 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalLoadFromStream (gpoi
+ 	MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)native_alc;
+ 	MonoReflectionAssemblyHandle result = MONO_HANDLE_CAST (MonoReflectionAssembly, NULL_HANDLE);
+ 	MonoAssembly *assm = NULL;
++	if (mono_alc_reject_if_torn_down (alc, error))
++		goto leave;
+ 	assm = mono_alc_load_raw_bytes (alc, (guint8 *)raw_assembly_ptr, raw_assembly_len, (guint8 *)raw_symbols_ptr, raw_symbols_len, error);
+ 	goto_if_nok (error, leave);
+ 
+@@ -1097,8 +1198,9 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
  {
  #ifdef DISABLE_THREADS
  	/*
@@ -699,7 +804,7 @@ index d8eac6e34..43f1121db 100644
  	 * The consult is a pure pointer-value comparison — the freed manager is NEVER
  	 * dereferenced — and consuming the entry retires exactly one scout: it returns TRUE,
  	 * so the finalizer does not GC.ReRegisterForFinalize and the scout population stays
-@@ -1109,6 +1178,67 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
+@@ -1109,6 +1211,67 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
  		retired_scout_terminal_count++;
  		return TRUE;
  	}
@@ -768,7 +873,7 @@ index d8eac6e34..43f1121db 100644
  
  	/* Not enabled yet */
 diff --git a/src/mono/mono/metadata/loader-internals.h b/src/mono/mono/metadata/loader-internals.h
-index 4275a39d2..b8f5e1f14 100644
+index 4275a39d2..aef5e44ae 100644
 --- a/src/mono/mono/metadata/loader-internals.h
 +++ b/src/mono/mono/metadata/loader-internals.h
 @@ -107,6 +107,13 @@ struct _MonoAssemblyLoadContext {
@@ -785,6 +890,19 @@ index 4275a39d2..b8f5e1f14 100644
  	// Used in native-library.c for the hash table below; do not access anywhere else
  	MonoCoopMutex pinvoke_lock;
  	// Maps malloc-ed char* pinvoke scope -> MonoDl*
+@@ -236,6 +243,12 @@ mono_alc_memory_managers_unlock (MonoAssemblyLoadContext *alc);
+ gboolean
+ mono_alc_is_default (MonoAssemblyLoadContext *alc);
+ 
++/* Sets InvalidOperationException on `error` and returns TRUE when the ALC was already torn
++ * down by the GC-driven scout completion (native_tombstoned): icalls receiving a raw native
++ * ALC pointer must reject before dereferencing state mono_alc_cleanup destroyed. */
++gboolean
++mono_alc_reject_if_torn_down (MonoAssemblyLoadContext *alc, MonoError *error);
++
+ MonoAssembly*
+ mono_alc_invoke_resolve_using_load_nofail (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname);
+ 
 -- 
 2.53.0.vfs.0.0
 

--- a/patches/0013-gc-driven-scout-completion-for-forced-alc-unload.patch
+++ b/patches/0013-gc-driven-scout-completion-for-forced-alc-unload.patch
@@ -90,14 +90,14 @@ leg, exactly like the field failure; green flag-off/threads):
 
 Refs https://github.com/unoplatform/Uno.DotnetRuntime.WebAssembly/issues/169.
 ---
- .../tests/ForcedNativeUnloadTests.cs          | 224 +++++++++++++++++-
+ .../tests/ForcedNativeUnloadTests.cs          | 225 +++++++++++++++++-
  .../Loader/AssemblyLoadContext.Mono.cs        |  14 +-
- .../mono/metadata/assembly-load-context.c     | 185 +++++++++++----
+ .../mono/metadata/assembly-load-context.c     | 185 ++++++++++----
  src/mono/mono/metadata/loader-internals.h     |   7 +
- 4 files changed, 383 insertions(+), 47 deletions(-)
+ 4 files changed, 384 insertions(+), 47 deletions(-)
 
 diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
-index 60708a1b5..ee90983aa 100644
+index 60708a1b5..c1063c8e3 100644
 --- a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 +++ b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 @@ -78,6 +78,10 @@ public class ForcedNativeUnloadTests
@@ -228,16 +228,17 @@ index 60708a1b5..ee90983aa 100644
          [Fact]
          public async Task ForcedUnload_RootedCrossContextGeneric_BlocksNativeFree()
          {
-@@ -949,6 +1063,28 @@ private static async Task RunRejectedCycles(int cycles)
-         // loop (mono_main_thread_schedule_background_job). Finalizers therefore never run inside a
-         // synchronous test method — awaiting Task.Delay turns the event loop and runs the pump.
-         [MethodImpl(MethodImplOptions.NoInlining)]
+@@ -936,6 +1050,29 @@ private static async Task RunRejectedCycles(int cycles)
+             }
+         }
+ 
 +        // Waits for a WeakReference to die across collections, turning the JS event loop between
 +        // attempts. The turns matter twice over: they re-dispatch the continuation on a nearly
 +        // empty interpreter stack (see ForceUntilCompletedAsync), and they let the scheduled
 +        // single-threaded finalizer pump run — the GC-driven scout completion (the teardown that
 +        // releases the native strong handle to the managed ALC) happens inside a finalizer, and
 +        // GC.WaitForPendingFinalizers alone is an immediate no-op on single-threaded wasm.
++        [MethodImpl(MethodImplOptions.NoInlining)]
 +        private static async Task CollectAndAssertDeadAsync(WeakReference weakRef, string reason)
 +        {
 +            for (int attempt = 0; attempt < 20; attempt++)
@@ -254,10 +255,10 @@ index 60708a1b5..ee90983aa 100644
 +            Assert.False(weakRef.IsAlive, reason);
 +        }
 +
-         private static async Task DrainRetiredScoutsAsync()
-         {
-             for (int attempt = 0; attempt < 20; attempt++)
-@@ -966,6 +1102,91 @@ private static async Task DrainRetiredScoutsAsync()
+         // Drive GC + finalization until the retired-scout set drains. Counter-based and bounded:
+         // each pass collects (queueing/re-queueing any scouts whose LoaderAllocator is dead,
+         // including ones that re-registered with FALSE on an earlier pass) and then lets finalizers
+@@ -966,6 +1103,91 @@ private static async Task DrainRetiredScoutsAsync()
              Assert.Equal(0, ScoutStats(RetiredSetSize));
          }
  
@@ -349,7 +350,7 @@ index 60708a1b5..ee90983aa 100644
          [MethodImpl(MethodImplOptions.NoInlining)]
          private static async Task<WeakReference> LoadExerciseUnloadAndForce()
          {
-@@ -1554,7 +1775,8 @@ private static void Churn(int rounds)
+@@ -1554,7 +1776,8 @@ private static void Churn(int rounds)
          // Holding asm/type/list in THIS frame across the force would keep the primary and
          // shared-generic LoaderAllocator witnesses alive and pin the force at NotQuiescent. Only
          // the ALC object itself lives here, which is safe: the runtime holds a strong handle to

--- a/patches/0013-gc-driven-scout-completion-for-forced-alc-unload.patch
+++ b/patches/0013-gc-driven-scout-completion-for-forced-alc-unload.patch
@@ -91,10 +91,10 @@ leg, exactly like the field failure; green flag-off/threads):
 Refs https://github.com/unoplatform/Uno.DotnetRuntime.WebAssembly/issues/169.
 ---
  .../tests/ForcedNativeUnloadTests.cs          | 224 +++++++++++++++++-
- .../Loader/AssemblyLoadContext.Mono.cs        |  11 +-
- .../mono/metadata/assembly-load-context.c     | 172 ++++++++++----
+ .../Loader/AssemblyLoadContext.Mono.cs        |  14 +-
+ .../mono/metadata/assembly-load-context.c     | 185 +++++++++++----
  src/mono/mono/metadata/loader-internals.h     |   7 +
- 4 files changed, 370 insertions(+), 44 deletions(-)
+ 4 files changed, 383 insertions(+), 47 deletions(-)
 
 diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 index 60708a1b5..ee90983aa 100644
@@ -360,7 +360,7 @@ index 60708a1b5..ee90983aa 100644
          private static async Task ReflectionHashInitUnderPressureCycle(int seed)
          {
 diff --git a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
-index 88ce94a0c..019acbad9 100644
+index 88ce94a0c..25ff655e0 100644
 --- a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
 +++ b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
 @@ -78,6 +78,12 @@ private static void KeepLoaderAllocator()
@@ -376,20 +376,23 @@ index 88ce94a0c..019acbad9 100644
          internal static int GetScoutRetirementStats(int kind) => InternalGetScoutRetirementStats(kind);
  
          [MethodImplAttribute(MethodImplOptions.InternalCall)]
-@@ -119,7 +125,10 @@ internal static int RunJiterpreterTableSelfTest()
+@@ -119,7 +125,13 @@ internal static int RunJiterpreterTableSelfTest()
          // in the native assembly-load-context.c.
          internal enum ForceNativeUnloadResult
          {
 -            // The native teardown ran to completion and the ALC was freed.
-+            // The native teardown ran to completion and the ALC was freed — either by this call,
-+            // or earlier by the GC-driven scout completion (the finalizer of the last
-+            // LoaderAllocator witness runs the same quiescence-gated teardown once the host's
-+            // roots are gone; this call then reports the already-completed state idempotently).
++            // The native teardown ran to completion: every memory manager, loaded image and
++            // GC handle of the context was released, and the context is terminally disposed.
++            // Performed either by this call (which also frees the native ALC struct) or earlier
++            // by the GC-driven scout completion (the finalizer of the last LoaderAllocator
++            // witness runs the same quiescence-gated teardown once the host's roots are gone,
++            // keeping the tiny struct as a tombstone so this call can report the
++            // already-completed state idempotently instead of dereferencing freed storage).
              Completed = 0,
              // The managed LoaderAllocator is still rooted (its weak handle target is non-NULL), so
              // freeing now would reclaim live memory. Nothing was freed; the caller should retry
 diff --git a/src/mono/mono/metadata/assembly-load-context.c b/src/mono/mono/metadata/assembly-load-context.c
-index d8eac6e34..3a550546d 100644
+index d8eac6e34..0590552c9 100644
 --- a/src/mono/mono/metadata/assembly-load-context.c
 +++ b/src/mono/mono/metadata/assembly-load-context.c
 @@ -80,6 +80,10 @@ alcs_unlock (void)
@@ -427,7 +430,7 @@ index d8eac6e34..3a550546d 100644
  	 */
  #ifdef DISABLE_THREADS
  	mono_loader_lock ();
-@@ -464,6 +470,56 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_PrepareForAssemblyLoadContex
+@@ -464,13 +470,67 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_PrepareForAssemblyLoadContex
  	mono_alc_memory_managers_unlock (alc);
  }
  
@@ -484,7 +487,19 @@ index d8eac6e34..3a550546d 100644
  int
  ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (gpointer alc_pointer, MonoError *error)
  {
-@@ -505,45 +561,19 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
+ 	/*
+ 	 * Host-triggered native teardown of a collectible ALC. Returns an outcome the managed
+ 	 * bridge maps to AssemblyLoadContext.ForceNativeUnloadResult:
+-	 *   0 = Completed     — the ALC was torn down and freed.
++	 *   0 = Completed     — the teardown ran to completion: every memory manager, loaded
++	 *                       image and GC handle was released. When this call performs the
++	 *                       teardown it also frees the ALC struct; when the GC-driven scout
++	 *                       completion performed it earlier, the struct was kept as a
++	 *                       tombstone and this call reports the state idempotently.
+ 	 *   1 = NotQuiescent  — managed roots to the ALC still exist; nothing freed, retry later.
+ 	 *   2 = Rejected      — feature unavailable (threads-enabled build), or null / default /
+ 	 *                       non-collectible / not-yet-unloading ALC.
+@@ -505,45 +565,19 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
  		return FORCE_UNLOAD_REJECTED;
  
  	/*
@@ -541,7 +556,7 @@ index d8eac6e34..3a550546d 100644
  		return FORCE_UNLOAD_NOT_QUIESCENT;
  
  	mono_alc_free (alc);
-@@ -593,6 +623,12 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+@@ -593,6 +627,12 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
  	 * mono_weak_hash_table_dead_lookup_count). Unconditional like kinds 2/3/5. A lifecycle test
  	 * uses it to prove the global assembly enumeration really took the terminal dead-cache path
  	 * for a condemned assembly (skipping it) instead of passing vacuously.
@@ -554,7 +569,7 @@ index d8eac6e34..3a550546d 100644
  	 */
  	if (kind == 2 || kind == 3)
  		return mono_weak_hash_table_key_value_handle_stats (kind - 2);
-@@ -611,6 +647,8 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+@@ -611,6 +651,8 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
  		return retired_scout_terminal_count;
  	case 4:
  		return mono_mem_manager_alc_unload_test_gc_hook_count ();
@@ -563,15 +578,29 @@ index d8eac6e34..3a550546d 100644
  	default:
  		return -1;
  	}
-@@ -1109,6 +1147,56 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
+@@ -1097,8 +1139,9 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
+ {
+ #ifdef DISABLE_THREADS
+ 	/*
+-	 * Terminal outcome for scouts whose memory manager was already freed by the forced
+-	 * native teardown (see the retired_scout_targets registry at the top of this file).
++	 * Terminal outcome for scouts whose memory manager was already freed by a completed
++	 * teardown — a forced attempt or an earlier scout completion, both run
++	 * mono_alc_cleanup (see the retired_scout_targets registry at the top of this file).
+ 	 * The consult is a pure pointer-value comparison — the freed manager is NEVER
+ 	 * dereferenced — and consuming the entry retires exactly one scout: it returns TRUE,
+ 	 * so the finalizer does not GC.ReRegisterForFinalize and the scout population stays
+@@ -1109,6 +1152,58 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
  		retired_scout_terminal_count++;
  		return TRUE;
  	}
 +
 +	/*
 +	 * GC-driven completion for the opt-in forced-unload flow. `native` was not in the
-+	 * retired registry, so it is a LIVE memory manager (only the forced teardown frees
-+	 * managers, and it registers every one it frees) and may be dereferenced. This scout
++	 * retired registry, so it is a LIVE memory manager and may be dereferenced: managers
++	 * are only ever freed by the two teardown initiators — a Completed forced attempt and
++	 * this scout completion, both via mono_alc_cleanup — and the cleanup registers every
++	 * manager it frees before any scout can observe it. This scout
 +	 * finalizing means ITS LoaderAllocator witness is dead; if the manager is owned by a
 +	 * collectible, unloading ALC whose WHOLE witness set is dead, complete the teardown
 +	 * here — a downstream WASM host doing repeated collectible-ALC load/unload cycles

--- a/patches/0013-gc-driven-scout-completion-for-forced-alc-unload.patch
+++ b/patches/0013-gc-driven-scout-completion-for-forced-alc-unload.patch
@@ -59,9 +59,16 @@ CoreCLR LoaderAllocatorScout design:
     is answered Completed by the claim CAS before reaching native, and
     the by-name/path/stream load icalls only ever receive the pointer
     through that getter. Mechanics are plain scalar stores (an IntPtr
-    and an int32; no reference writes, no barrier concerns;
-    mono_class_get_field_from_name_full walks the parent chain to the
-    declaring class for host subclasses); no reader can hold a
+    and an int32; no reference writes, no barrier concerns) resolved
+    from the DECLARING System.Runtime.Loader.AssemblyLoadContext class
+    (mono_class_get_assembly_load_context_class) rather than the
+    wrapper's dynamic class: field lookup searches the supplied class
+    before walking to its parent, so a legal host subclass shadowing
+    the field names would otherwise be latched in the wrong storage --
+    leaving the freed pointer reachable through the real base field --
+    and would poison the cached field descriptors for every later
+    wrapper; type and declaring-class asserts pin the resolution. No
+    reader can hold a
     pre-latch pointer across the scout run because finalizers on the
     single-threaded browser runtime execute as scheduled event-loop
     jobs -- never mid-icall, never between a NativeALC read and the
@@ -154,16 +161,25 @@ New lifecycle tests:
     kept scout-completed structs as host-retry-freed tombstones, which
     a never-retrying host leaked one per cycle, unbounded and
     invisible to kind 8.
+  * ScoutCompletion_LatchesBaseFields_WhenSubclassHidesThem -- the
+    field-shadowing regression: a legal subclass hiding both latch
+    field names is driven through the scout completion FIRST, then a
+    normal subclass in the same test (so the shared field cache cannot
+    mask a wrong-class resolution through process ordering); both must
+    reject ordinary loads via the terminal latch and answer retries
+    from the managed claim -- with a dynamic-class lookup the hiding
+    context's load would be a native use-after-free and its retry
+    would re-enter the native teardown with a freed pointer.
 
 Refs https://github.com/unoplatform/Uno.DotnetRuntime.WebAssembly/issues/169.
 ---
- .../tests/ForcedNativeUnloadTests.cs          | 323 +++++++++++++++++-
+ .../tests/ForcedNativeUnloadTests.cs          | 417 +++++++++++++++++-
  .../Loader/AssemblyLoadContext.Mono.cs        |  24 +-
- .../mono/metadata/assembly-load-context.c     | 296 +++++++++++++---
- 3 files changed, 593 insertions(+), 50 deletions(-)
+ .../mono/metadata/assembly-load-context.c     | 312 +++++++++++--
+ 3 files changed, 703 insertions(+), 50 deletions(-)
 
 diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
-index 60708a1b5..9e52b8a6c 100644
+index 60708a1b5..0781e05f9 100644
 --- a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 +++ b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 @@ -78,6 +78,17 @@ public class ForcedNativeUnloadTests
@@ -184,7 +200,7 @@ index 60708a1b5..9e52b8a6c 100644
  
          private static readonly MethodInfo s_forceNativeUnload = typeof(AssemblyLoadContext)
              .GetMethod("ForceNativeUnload", BindingFlags.NonPublic | BindingFlags.Instance);
-@@ -269,6 +280,207 @@ public async Task ForcedUnload_OnlyCompletesOnceQuiescent()
+@@ -269,6 +280,301 @@ public async Task ForcedUnload_OnlyCompletesOnceQuiescent()
              }
          }
  
@@ -323,6 +339,100 @@ index 60708a1b5..9e52b8a6c 100644
 +                "a retried forced unload must leave the context reclaimable with zero residual.");
 +        }
 +
++        // A LEGAL host subclass that hides both latch field names. The native scout latch must
++        // resolve the REAL fields on System.Runtime.Loader.AssemblyLoadContext itself — a
++        // lookup started from the wrapper's dynamic class finds these shadows first, latches
++        // the wrong storage, leaves the freed native pointer reachable through the real base
++        // field (use-after-free on the next ordinary load), and poisons the process-wide field
++        // cache for every later wrapper.
++        private sealed class FieldHidingAssemblyLoadContext : ResourceAssemblyLoadContext
++        {
++#pragma warning disable CS0169, CS0414, IDE0051 // deliberate name shadows, never read
++            private IntPtr _nativeAssemblyLoadContext;
++            private int _nativeUnloadForced;
++#pragma warning restore CS0169, CS0414, IDE0051
++
++            public FieldHidingAssemblyLoadContext()
++                : base(isCollectible: true)
++            {
++                LoadBy = LoadBy.Stream;
++            }
++        }
++
++        /// <summary>
++        /// Field-shadowing regression for the scout latch: the latch must write the DECLARING
++        /// class's fields, not whatever a subclass put in front of them by name. Runs the
++        /// hiding subclass FIRST and a normal subclass SECOND in the same test, so the shared
++        /// MonoClassField cache cannot mask a wrong-class resolution through lucky process
++        /// ordering: if the hiding subclass had poisoned the cache, the normal context's latch
++        /// would break too — and if the lookup started from the dynamic class, the hiding
++        /// context's post-completion load would be a native use-after-free rather than the
++        /// asserted managed rejection, and its retry would re-enter the native teardown with a
++        /// freed pointer instead of being answered by the managed claim latch.
++        /// </summary>
++        [Fact]
++        public async Task ScoutCompletion_LatchesBaseFields_WhenSubclassHidesThem()
++        {
++            if (BridgeMissing())
++            {
++                return;
++            }
++
++            int structsBefore = ScoutStats(NativeStructsGauge);
++
++            int scoutBeforeHiding = ProtocolActive ? ScoutStats(ScoutCompletedTeardownCount) : 0;
++            var hiding = new FieldHidingAssemblyLoadContext();
++            var weakHiding = new WeakReference(hiding);
++            FirstAttemptOnRootedContext(hiding);
++
++            if (ProtocolActive)
++            {
++                await PumpUntilScoutCompletionAsync(scoutBeforeHiding);
++
++                // (a) The REAL base fields were latched: ordinary loads reject in managed code
++                // via the terminal latch, never reading the freed pointer.
++                Assert.Throws<ObjectDisposedException>(
++                    () => hiding.LoadFromAssemblyName(new AssemblyName(TestAssembly)));
++                // (b) Retries are answered by the managed claim latch, idempotently, without
++                // re-entering the native teardown.
++                Assert.Equal(Completed, Force(hiding));
++                Assert.Equal(Completed, Force(hiding));
++            }
++            else
++            {
++                Assert.Equal(Rejected, Force(hiding));
++            }
++
++            // Normal subclass second: proves the field cache the hiding subclass populated
++            // first still latches every later wrapper correctly.
++            int scoutBeforeNormal = ProtocolActive ? ScoutStats(ScoutCompletedTeardownCount) : 0;
++            var normal = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
++            var weakNormal = new WeakReference(normal);
++            FirstAttemptOnRootedContext(normal);
++
++            if (ProtocolActive)
++            {
++                await PumpUntilScoutCompletionAsync(scoutBeforeNormal);
++                Assert.Throws<ObjectDisposedException>(
++                    () => normal.LoadFromAssemblyName(new AssemblyName(TestAssembly)));
++                Assert.Equal(Completed, Force(normal));
++                await DrainRetiredScoutsAsync();
++                Assert.Equal(0, ScoutStats(PendingUnloadsGauge));
++                Assert.Equal(structsBefore, ScoutStats(NativeStructsGauge));
++            }
++            else
++            {
++                Assert.Equal(Rejected, Force(normal));
++            }
++
++            hiding = null;
++            normal = null;
++            await CollectAndAssertDeadAsync(weakHiding,
++                "a field-hiding subclass context must be reclaimable after the scout completion latched the base fields.");
++            await CollectAndAssertDeadAsync(weakNormal,
++                "a normal subclass context must stay reclaimable after a field-hiding subclass resolved the latch cache first.");
++        }
++
 +        /// <summary>
 +        /// The no-retry residue regression: a host that never calls ForceNativeUnload at all —
 +        /// N load/unload/drop cycles — must leave NO native residue. An earlier revision kept
@@ -392,7 +502,7 @@ index 60708a1b5..9e52b8a6c 100644
          [Fact]
          public async Task ForcedUnload_RootedCrossContextGeneric_BlocksNativeFree()
          {
-@@ -936,6 +1148,29 @@ private static async Task RunRejectedCycles(int cycles)
+@@ -936,6 +1242,29 @@ private static async Task RunRejectedCycles(int cycles)
              }
          }
  
@@ -422,7 +532,7 @@ index 60708a1b5..9e52b8a6c 100644
          // Drive GC + finalization until the retired-scout set drains. Counter-based and bounded:
          // each pass collects (queueing/re-queueing any scouts whose LoaderAllocator is dead,
          // including ones that re-registered with FALSE on an earlier pass) and then lets finalizers
-@@ -966,6 +1201,91 @@ private static async Task DrainRetiredScoutsAsync()
+@@ -966,6 +1295,91 @@ private static async Task DrainRetiredScoutsAsync()
              Assert.Equal(0, ScoutStats(RetiredSetSize));
          }
  
@@ -514,7 +624,7 @@ index 60708a1b5..9e52b8a6c 100644
          [MethodImpl(MethodImplOptions.NoInlining)]
          private static async Task<WeakReference> LoadExerciseUnloadAndForce()
          {
-@@ -1554,7 +1874,8 @@ private static void Churn(int rounds)
+@@ -1554,7 +1968,8 @@ private static void Churn(int rounds)
          // Holding asm/type/list in THIS frame across the force would keep the primary and
          // shared-generic LoaderAllocator witnesses alive and pin the force at NotQuiescent. Only
          // the ALC object itself lives here, which is safe: the runtime holds a strong handle to
@@ -567,7 +677,7 @@ index 88ce94a0c..7bbf6a7d1 100644
              // The managed LoaderAllocator is still rooted (its weak handle target is non-NULL), so
              // freeing now would reclaim live memory. Nothing was freed; the caller should retry
 diff --git a/src/mono/mono/metadata/assembly-load-context.c b/src/mono/mono/metadata/assembly-load-context.c
-index d8eac6e34..a47a5ef03 100644
+index d8eac6e34..67cb51a0c 100644
 --- a/src/mono/mono/metadata/assembly-load-context.c
 +++ b/src/mono/mono/metadata/assembly-load-context.c
 @@ -9,6 +9,7 @@
@@ -810,7 +920,7 @@ index d8eac6e34..a47a5ef03 100644
  	default:
  		return -1;
  	}
-@@ -1092,13 +1166,68 @@ mono_alc_get_all (void)
+@@ -1092,13 +1166,84 @@ mono_alc_get_all (void)
  	return all_alcs;
  }
  
@@ -833,8 +943,16 @@ index d8eac6e34..a47a5ef03 100644
 + *     what mono_alc_cleanup is about to release, so the target is still rooted.
 + *   - Both fields are unmanaged scalars (an IntPtr and an int32) — no reference writes,
 + *     so no write-barrier concerns; mono_field_set_value_internal on instance scalar
-+ *     fields is a plain store. The wrapper may be a host subclass;
-+ *     mono_class_get_field_from_name_full walks the parent chain to the declaring class.
++ *     fields is a plain store. The wrapper may be a host subclass, and a LEGAL subclass
++ *     may declare private fields with the SAME NAMES — mono_class_get_field_from_name_full
++ *     searches the supplied class before walking to the parent, so the lookup MUST start
++ *     from the declaring System.Runtime.Loader.AssemblyLoadContext class itself
++ *     (mono_class_get_assembly_load_context_class), never from the wrapper's dynamic
++ *     class: resolving from the subclass would latch the shadowing subclass storage,
++ *     leave the real base fields unlatched (freed pointer still reachable, claim still
++ *     idle), and — because the resolved MonoClassField descriptors are cached — poison
++ *     the latch for every later wrapper in the process. The type and declaring-class
++ *     asserts below pin the resolution.
 + *   - No reader can hold a pre-latch pointer across this run: on the single-threaded
 + *     browser runtime, finalizers execute as scheduled event-loop jobs — never mid-icall
 + *     and never between a NativeALC read and the icall it feeds within one synchronous
@@ -851,14 +969,22 @@ index d8eac6e34..a47a5ef03 100644
 +	g_assert (wrapper); /* strong handle — released only by the cleanup that follows */
 +
 +	if (!pointer_field || !claim_field) {
-+		/* Cache on the declaring class: field lookup walks parents, and the resolved
-+		 * MonoClassField of System.Runtime.Loader.AssemblyLoadContext is the same for
-+		 * every subclass instance. */
-+		MonoClass *klass = mono_object_class (wrapper);
-+		pointer_field = mono_class_get_field_from_name_full (klass, "_nativeAssemblyLoadContext", NULL);
-+		claim_field = mono_class_get_field_from_name_full (klass, "_nativeUnloadForced", NULL);
++		/* Resolve from the DECLARING class, not the wrapper's dynamic class: a subclass
++		 * field with the same name would otherwise shadow the real one (lookup searches
++		 * the supplied class first) and the cached descriptors would poison every later
++		 * wrapper. The declaring class is the same for every subclass instance, so the
++		 * cache is order-independent. */
++		MonoClass *alc_class = mono_class_get_assembly_load_context_class ();
++		g_assert (alc_class);
++		pointer_field = mono_class_get_field_from_name_full (alc_class, "_nativeAssemblyLoadContext", NULL);
++		claim_field = mono_class_get_field_from_name_full (alc_class, "_nativeUnloadForced", NULL);
 +		g_assert (pointer_field);
 +		g_assert (claim_field);
++		/* Pin the resolution: exact declaring class and exact unmanaged scalar types. */
++		g_assert (m_field_get_parent (pointer_field) == alc_class);
++		g_assert (m_field_get_parent (claim_field) == alc_class);
++		g_assert (pointer_field->type->type == MONO_TYPE_I);
++		g_assert (claim_field->type->type == MONO_TYPE_I4);
 +	}
 +
 +	gpointer zero = NULL;
@@ -881,7 +1007,7 @@ index d8eac6e34..a47a5ef03 100644
  	 * The consult is a pure pointer-value comparison — the freed manager is NEVER
  	 * dereferenced — and consuming the entry retires exactly one scout: it returns TRUE,
  	 * so the finalizer does not GC.ReRegisterForFinalize and the scout population stays
-@@ -1109,6 +1238,77 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
+@@ -1109,6 +1254,77 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
  		retired_scout_terminal_count++;
  		return TRUE;
  	}

--- a/patches/0013-gc-driven-scout-completion-for-forced-alc-unload.patch
+++ b/patches/0013-gc-driven-scout-completion-for-forced-alc-unload.patch
@@ -43,47 +43,35 @@ CoreCLR LoaderAllocatorScout design:
     plain GC now reclaims the managed ALC with no host retry. If the
     set is not yet fully dead the scout re-registers for finalization
     (the pre-existing managed retry loop) and tries again next GC.
-  * Tombstone, then reclaim on retry: the scout-driven path keeps the
-    tiny MonoAssemblyLoadContext struct alive with a new
-    native_tombstoned flag (loader-internals.h) instead of g_free-ing
-    it, because a host may still hold the managed context and
-    legitimately retry ForceNativeUnload later -- that retry carries
-    the raw native pointer, so freeing the struct eagerly would be a
-    use-after-free. The forced icall answers a tombstoned ALC with an
-    idempotent Completed (before its own quiescence walk) AND frees the
-    struct right there: that retry is provably the LAST carrier of the
-    pointer -- the cleanup already released every other native
-    reference (global-list membership, images, managers, name,
-    gchandle), and on Completed the managed wrapper zeroes its pointer
-    and latches the terminal claim, whose CAS short-circuits every
-    later call before it can reach the icall. Managed load APIs were
-    already rejected from the moment Unload() was initiated, so nothing
-    else can carry the stale pointer into native code. Only hosts that
-    NEVER retry keep the ~one-hundred-byte struct per unloaded context
-    -- the documented, bounded residual of the scout-completed path (a
-    Completed forced attempt still frees everything at once, as
-    before).
-  * Torn-down guard at the icall boundary: between the scout
-    completion and a host retry, the surviving managed wrapper still
-    carries the raw native pointer with an idle claim, and the BY-NAME
-    load path (LoadFromAssemblyName ->
-    Assembly/RuntimeAssembly.InternalLoad) reaches the native ALC
-    without any managed VerifyIsAlive gate -- an ordinary load in that
-    window would walk into state mono_alc_cleanup already destroyed
-    (assemblies_lock, loaded_images): a use-after-destroy, not an
-    exception. Every icall that receives the raw pointer (InternalLoad
-    by-name, InternalLoadFile, InternalLoadFromStream) now rejects a
-    native_tombstoned context up front with InvalidOperationException
-    (mono_alc_reject_if_torn_down); reading the flag is safe because
-    the struct is freed only by the claim-gated retry, and the managed
-    NativeALC getter blocks every consumer once that claim is latched.
-    Loads into an unloading-but-not-yet-torn-down context
-    intentionally keep working: the native side is fully functional
-    there, and upstream also services cached by-name resolves during
-    the unloading window (the path/stream entry points
-    VerifyIsAlive-reject there, upstream and here alike), so a blanket
-    managed unloading guard on the by-name path would change
-    contractual behavior default consumers rely on.
+  * Terminal latch, then outright free -- no native residue: before
+    releasing anything, the scout completion latches the surviving
+    managed wrapper to its terminal disposed state from native
+    (scout_latch_managed_wrapper): it zeroes _nativeAssemblyLoadContext
+    and then sets the _nativeUnloadForced claim to 2 -- the same two
+    writes, in the same order, the managed ForceNativeUnload path
+    performs on Completed. The wrapper cannot be dead at that moment:
+    the strong gchandle Prepare installed is exactly what the cleanup
+    is about to release, so the target is still rooted. With the latch
+    in place the struct is freed outright (mono_alc_free, the same
+    single free site the forced attempt uses): no consumer can ever
+    carry the freed pointer into an icall again -- the NativeALC
+    getter rejects on either latch signal, a ForceNativeUnload retry
+    is answered Completed by the claim CAS before reaching native, and
+    the by-name/path/stream load icalls only ever receive the pointer
+    through that getter. Mechanics are plain scalar stores (an IntPtr
+    and an int32; no reference writes, no barrier concerns;
+    mono_class_get_field_from_name_full walks the parent chain to the
+    declaring class for host subclasses); no reader can hold a
+    pre-latch pointer across the scout run because finalizers on the
+    single-threaded browser runtime execute as scheduled event-loop
+    jobs -- never mid-icall, never between a NativeALC read and the
+    icall it feeds within one synchronous managed statement, and never
+    while a forced attempt's claim is in flight. Loads into an
+    unloading-but-not-yet-torn-down context intentionally keep
+    working: the native side is fully functional there, and upstream
+    also services cached by-name resolves during the unloading window
+    (the path/stream entry points VerifyIsAlive-reject there, upstream
+    and here alike).
   * No zero-witness hole: every opted-in collectible ALC eagerly
     materialises its primary LoaderAllocator -- and therefore a scout
     and a weak witness -- at creation (mono_alc_init calls
@@ -105,10 +93,15 @@ CoreCLR LoaderAllocatorScout design:
     scout path rather than passing vacuously -- under the opt-in the
     strong handle makes ALC death impossible any other way, and the
     stat pins it explicitly. Kind 8 is a gauge of collectible,
-    unloading, not-yet-torn-down ALCs: a witness that never dies would
-    otherwise be observable only as silent scout re-registration,
+    unloading ALCs still on the global list: a witness that never dies
+    would otherwise be observable only as silent scout re-registration,
     indistinguishable from the pre-fix strand; the tests assert the
-    gauge drains back to 0 after every cycle.
+    gauge drains back to 0 after every cycle. Kind 9 is a
+    creation/free ledger of the native ALC structs of collectible
+    contexts (single free site: mono_alc_free, shared by both teardown
+    initiators), so any path that loses a struct -- the orphan class
+    of bug kind 8 cannot see, an orphan being off the global list --
+    fails to drain the gauge back to its baseline.
 
 Alternatives considered and rejected:
 
@@ -144,30 +137,36 @@ New lifecycle tests:
     purest contract: no attempt at all; same reclaim, same exact kind-7
     proof. RED on the previous runtime for the flag-on leg.
   * ForcedUnload_RetryAfterRootsDropped_CompletesWithZeroResidual --
-    NOT a strand red (it also passes pre-fix): it deterministically
-    covers the tombstone-retry branch (the UAF guard) by pumping GC
-    until kind-7 advances BEFORE retrying, asserts an ordinary by-name
-    load in the tombstone window rejects in managed code (on unguarded
-    code that call is a native use-after-destroy, so this leg is red
-    without the icall guard), then asserts the retry Completes, that a
-    further call is answered by the managed terminal-claim latch, and
-    that the scout registry and the pending-unloads gauge drain to
-    zero.
+    NOT a strand red (parts also pass pre-fix): it pumps GC until
+    kind-7 advances so its assertions deterministically probe the
+    post-scout-completion window, then asserts an ordinary by-name
+    load rejects in managed code via the terminal latch (on a runtime
+    that freed the struct without latching the wrapper, that call is a
+    native use-after-free), that the retry and any further call are
+    answered Completed by the claim CAS without entering the icall,
+    and that the scout registry, the pending-unloads gauge and the
+    native-struct ledger all return to baseline.
+  * RepeatedUnloadWithoutRetry_NativeStructPopulationReturnsToBaseline
+    -- the no-retry residue regression: N load/unload/drop cycles with
+    ForceNativeUnload never called; every wrapper must die by plain
+    GC, kind-7 must advance by exactly N, and the kind-9 ledger must
+    return exactly to its pre-test baseline -- an earlier revision
+    kept scout-completed structs as host-retry-freed tombstones, which
+    a never-retrying host leaked one per cycle, unbounded and
+    invisible to kind 8.
 
 Refs https://github.com/unoplatform/Uno.DotnetRuntime.WebAssembly/issues/169.
 ---
- .../tests/ForcedNativeUnloadTests.cs          | 271 +++++++++++++++++-
- .../Loader/AssemblyLoadContext.Mono.cs        |  18 +-
- src/mono/mono/metadata/appdomain.c            |   7 +
- .../mono/metadata/assembly-load-context.c     | 251 +++++++++++++---
- src/mono/mono/metadata/loader-internals.h     |  13 +
- 5 files changed, 514 insertions(+), 46 deletions(-)
+ .../tests/ForcedNativeUnloadTests.cs          | 323 +++++++++++++++++-
+ .../Loader/AssemblyLoadContext.Mono.cs        |  24 +-
+ .../mono/metadata/assembly-load-context.c     | 296 +++++++++++++---
+ 3 files changed, 593 insertions(+), 50 deletions(-)
 
 diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
-index 60708a1b5..4bc5107b3 100644
+index 60708a1b5..9e52b8a6c 100644
 --- a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 +++ b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
-@@ -78,6 +78,13 @@ public class ForcedNativeUnloadTests
+@@ -78,6 +78,17 @@ public class ForcedNativeUnloadTests
          // manager's LoaderAllocator; mono_weak_hash_table_dead_lookup_count). Unconditional
          // shared-runtime code, like kinds 2/3/5.
          private const int WeakTableDeadLookupCount = 6;
@@ -178,10 +177,14 @@ index 60708a1b5..4bc5107b3 100644
 +        // GAUGE (not monotonic): collectible, unloading ALCs whose teardown has not completed
 +        // yet. Makes a never-dying witness visible; must drain back to 0 after every cycle.
 +        private const int PendingUnloadsGauge = 8;
++        // GAUGE (not monotonic): native ALC structs of collectible contexts currently allocated
++        // (creation/free ledger). Catches the orphaned-struct class of bug kind 8 cannot see —
++        // an orphan is off the global list — by failing to drain back to its baseline.
++        private const int NativeStructsGauge = 9;
  
          private static readonly MethodInfo s_forceNativeUnload = typeof(AssemblyLoadContext)
              .GetMethod("ForceNativeUnload", BindingFlags.NonPublic | BindingFlags.Instance);
-@@ -269,6 +276,159 @@ public async Task ForcedUnload_OnlyCompletesOnceQuiescent()
+@@ -269,6 +280,207 @@ public async Task ForcedUnload_OnlyCompletesOnceQuiescent()
              }
          }
  
@@ -260,18 +263,22 @@ index 60708a1b5..4bc5107b3 100644
 +        }
 +
 +        /// <summary>
-+        /// A host that DOES retry after dropping its roots must observe Completed — and this
-+        /// test makes the retry deterministically exercise the native tombstone branch, the
-+        /// use-after-free guard: it first pumps GC until the scout completion has provably
-+        /// performed the teardown (exact kind-7 advance) and only then retries. Without that
-+        /// ordering the retry races the scheduled scout finalizer, and whenever the retry won
-+        /// it would complete through the ordinary quiescence walk, leaving the tombstone branch
-+        /// permanently uncovered while staying green. The tombstoned retry also reclaims the
-+        /// struct; a further call is answered by the managed terminal-claim latch and never
-+        /// reaches native code at all. "Zero residual" means the scout registry drains and the
-+        /// pending-unloads gauge returns to 0 — the struct itself was freed by the retry.
-+        /// (Unlike the two strand regressions above, this test also passes on the pre-fix
-+        /// runtime: it guards the retry contract and the tombstone coverage, not the strand.)
++        /// A host that DOES retry after dropping its roots must observe Completed, and the
++        /// post-completion window must be fully sealed. The test pumps GC until the scout
++        /// completion has provably performed the teardown (exact kind-7 advance) — the scout
++        /// path latches the surviving wrapper to its terminal state natively (pointer zeroed,
++        /// claim 2) BEFORE freeing the struct outright, so in this window:
++        ///   * an ordinary load API must reject in managed code via the terminal latch
++        ///     (ObjectDisposedException from the NativeALC getter) — the freed native pointer
++        ///     must be unreachable from every consumer, and on a runtime that freed the struct
++        ///     without latching the wrapper this call would be a native use-after-free;
++        ///   * the retry (and any further call) must be answered Completed by the managed
++        ///     claim CAS without entering the icall at all.
++        /// "Zero residual" means: the scout registry drains, the pending-unloads gauge returns
++        /// to 0, and the native-struct ledger (kind 9) returns to its pre-test baseline —
++        /// nothing native survives the cycle. (Unlike the two strand regressions above, parts
++        /// of this test also pass on the pre-fix runtime: it guards the retry contract and the
++        /// sealed post-completion surface, not the strand.)
 +        /// </summary>
 +        [Fact]
 +        public async Task ForcedUnload_RetryAfterRootsDropped_CompletesWithZeroResidual()
@@ -281,6 +288,7 @@ index 60708a1b5..4bc5107b3 100644
 +                return;
 +            }
 +
++            int structsBefore = ProtocolActive ? ScoutStats(NativeStructsGauge) : 0;
 +            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
 +            var weakRef = new WeakReference(context);
 +            int scoutCompletionsBefore = ProtocolActive ? ScoutStats(ScoutCompletedTeardownCount) : 0;
@@ -289,25 +297,21 @@ index 60708a1b5..4bc5107b3 100644
 +            if (ProtocolActive)
 +            {
 +                // Deterministic ordering: wait until the scout completion performed the
-+                // teardown, so the retry below provably lands on native_tombstoned.
++                // teardown, so the assertions below probe the post-completion window.
 +                await PumpUntilScoutCompletionAsync(scoutCompletionsBefore);
 +
-+                // The tombstone window: the wrapper still carries the raw native pointer and
-+                // its claim is idle, so an ordinary load API must reject BEFORE any native
-+                // dereference of the destroyed state (assemblies_lock, loaded_images). The
-+                // by-name path has no managed VerifyIsAlive gate, so the reject comes from the
-+                // native torn-down guard at the icall entry — on unguarded code this call is a
-+                // native use-after-destroy (crash), not an exception.
-+                Assert.Throws<InvalidOperationException>(
++                // The wrapper was latched terminal by the scout path, so ordinary load APIs
++                // reject in managed code before the (already freed) pointer could be read.
++                Assert.Throws<ObjectDisposedException>(
 +                    () => context.LoadFromAssemblyName(new AssemblyName(TestAssembly)));
 +
-+                // The retry hits the tombstone branch: idempotent Completed, struct reclaimed.
++                // The retry is answered by the managed terminal-claim latch (prior == 2),
++                // never reaching native code; so is any further call.
 +                Assert.Equal(Completed, Force(context));
-+                // A further call never reaches native: the managed terminal-claim latch
-+                // (prior == 2) answers before the icall.
 +                Assert.Equal(Completed, Force(context));
 +                await DrainRetiredScoutsAsync();
 +                Assert.Equal(0, ScoutStats(PendingUnloadsGauge));
++                Assert.Equal(structsBefore, ScoutStats(NativeStructsGauge));
 +            }
 +            else
 +            {
@@ -317,6 +321,53 @@ index 60708a1b5..4bc5107b3 100644
 +            context = null;
 +            await CollectAndAssertDeadAsync(weakRef,
 +                "a retried forced unload must leave the context reclaimable with zero residual.");
++        }
++
++        /// <summary>
++        /// The no-retry residue regression: a host that never calls ForceNativeUnload at all —
++        /// N load/unload/drop cycles — must leave NO native residue. An earlier revision kept
++        /// the scout-completed ALC struct as a native tombstone whose only free site was a
++        /// host retry, so a never-retrying host leaked one ~100-byte struct per cycle,
++        /// unbounded over process lifetime, invisible to the pending-unloads gauge (an orphan
++        /// is off the global list). The native-struct ledger (kind 9) counts creations against
++        /// the single free site, so any teardown path that loses a struct fails the exact
++        /// baseline-return assertion here.
++        /// </summary>
++        [Fact]
++        public async Task RepeatedUnloadWithoutRetry_NativeStructPopulationReturnsToBaseline()
++        {
++            if (BridgeMissing())
++            {
++                return;
++            }
++
++            const int Cycles = 5;
++            int structsBefore = ScoutStats(NativeStructsGauge);
++            int scoutCompletionsBefore = ProtocolActive ? ScoutStats(ScoutCompletedTeardownCount) : 0;
++
++            var refs = new WeakReference[Cycles];
++            for (int i = 0; i < Cycles; i++)
++            {
++                refs[i] = LoadRootUnloadAndDrop();
++            }
++
++            foreach (WeakReference weakRef in refs)
++            {
++                await CollectAndAssertDeadAsync(weakRef,
++                    "every unloaded context must be reclaimed by plain GC without any forced attempt.");
++            }
++
++            // The ledger must return exactly to its baseline: creations balanced by frees. On
++            // the flag-off leg the gauge never moves (nothing is natively collectible) and on
++            // the threads-enabled leg it reports -1 throughout, so the equality holds — and is
++            // meaningful — on every leg.
++            Assert.Equal(structsBefore, ScoutStats(NativeStructsGauge));
++
++            if (ProtocolActive)
++            {
++                Assert.Equal(scoutCompletionsBefore + Cycles, ScoutStats(ScoutCompletedTeardownCount));
++                Assert.Equal(0, ScoutStats(PendingUnloadsGauge));
++            }
 +        }
 +
 +        // Pumps GC and the event-loop finalizer pump until the GC-driven scout completion has
@@ -341,7 +392,7 @@ index 60708a1b5..4bc5107b3 100644
          [Fact]
          public async Task ForcedUnload_RootedCrossContextGeneric_BlocksNativeFree()
          {
-@@ -936,6 +1096,29 @@ private static async Task RunRejectedCycles(int cycles)
+@@ -936,6 +1148,29 @@ private static async Task RunRejectedCycles(int cycles)
              }
          }
  
@@ -371,7 +422,7 @@ index 60708a1b5..4bc5107b3 100644
          // Drive GC + finalization until the retired-scout set drains. Counter-based and bounded:
          // each pass collects (queueing/re-queueing any scouts whose LoaderAllocator is dead,
          // including ones that re-registered with FALSE on an earlier pass) and then lets finalizers
-@@ -966,6 +1149,91 @@ private static async Task DrainRetiredScoutsAsync()
+@@ -966,6 +1201,91 @@ private static async Task DrainRetiredScoutsAsync()
              Assert.Equal(0, ScoutStats(RetiredSetSize));
          }
  
@@ -463,7 +514,7 @@ index 60708a1b5..4bc5107b3 100644
          [MethodImpl(MethodImplOptions.NoInlining)]
          private static async Task<WeakReference> LoadExerciseUnloadAndForce()
          {
-@@ -1554,7 +1822,8 @@ private static void Churn(int rounds)
+@@ -1554,7 +1874,8 @@ private static void Churn(int rounds)
          // Holding asm/type/list in THIS frame across the force would keep the primary and
          // shared-generic LoaderAllocator witnesses alive and pin the force at NotQuiescent. Only
          // the ALC object itself lives here, which is safe: the runtime holds a strong handle to
@@ -474,10 +525,10 @@ index 60708a1b5..4bc5107b3 100644
          private static async Task ReflectionHashInitUnderPressureCycle(int seed)
          {
 diff --git a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
-index 88ce94a0c..707d2ec1f 100644
+index 88ce94a0c..7bbf6a7d1 100644
 --- a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
 +++ b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
-@@ -78,6 +78,16 @@ private static void KeepLoaderAllocator()
+@@ -78,6 +78,21 @@ private static void KeepLoaderAllocator()
          // cycles rather than growing by three per reflection-using memory manager. Unlike kinds
          // 0/1 these are available on every build, because the ownership fix they observe is
          // unconditional (not part of the DISABLE_THREADS-gated forced teardown).
@@ -491,47 +542,43 @@ index 88ce94a0c..707d2ec1f 100644
 +        // Kind 8 is a GAUGE (not monotonic): collectible, unloading ALCs whose teardown has not
 +        // completed yet. A witness that never dies is otherwise observable only as silent scout
 +        // re-registration; this makes pending unloads visible, and tests assert it drains to 0.
++        //
++        // Kind 9 is a GAUGE (not monotonic): native ALC structs of collectible contexts
++        // currently allocated (creation/free ledger). Any teardown path that loses a struct —
++        // which kind 8 cannot see, an orphan being off the global list — fails to drain this
++        // back to its baseline across load/unload cycles; tests assert the exact return.
          internal static int GetScoutRetirementStats(int kind) => InternalGetScoutRetirementStats(kind);
  
          [MethodImplAttribute(MethodImplOptions.InternalCall)]
-@@ -119,7 +129,13 @@ internal static int RunJiterpreterTableSelfTest()
+@@ -119,7 +134,14 @@ internal static int RunJiterpreterTableSelfTest()
          // in the native assembly-load-context.c.
          internal enum ForceNativeUnloadResult
          {
 -            // The native teardown ran to completion and the ALC was freed.
-+            // The native teardown ran to completion: every memory manager, loaded image and
-+            // GC handle of the context was released, and the context is terminally disposed.
-+            // Performed either by this call (which also frees the native ALC struct) or earlier
-+            // by the GC-driven scout completion (the finalizer of the last LoaderAllocator
-+            // witness runs the same quiescence-gated teardown once the host's roots are gone,
-+            // keeping the tiny struct as a tombstone so this call can report the
-+            // already-completed state idempotently instead of dereferencing freed storage).
++            // The native teardown ran to completion: every memory manager, loaded image, GC
++            // handle AND the native ALC struct itself were released, and the context is
++            // terminally disposed. Performed either by this call, or by the GC-driven scout
++            // completion (the finalizer of the last LoaderAllocator witness runs the same
++            // quiescence-gated teardown once the host's roots are gone; before freeing, it
++            // latches this wrapper to the terminal state natively — pointer zeroed, claim 2 —
++            // so a later retry is answered by the claim CAS in managed code and the freed
++            // pointer can never reach an icall again).
              Completed = 0,
              // The managed LoaderAllocator is still rooted (its weak handle target is non-NULL), so
              // freeing now would reclaim live memory. Nothing was freed; the caller should retry
-diff --git a/src/mono/mono/metadata/appdomain.c b/src/mono/mono/metadata/appdomain.c
-index f0a778910..29a5abbbe 100644
---- a/src/mono/mono/metadata/appdomain.c
-+++ b/src/mono/mono/metadata/appdomain.c
-@@ -781,6 +781,13 @@ ves_icall_System_Reflection_Assembly_InternalLoad (MonoStringHandle name_handle,
- 		g_assert_not_reached ();
- 
- 	g_assert (alc);
-+
-+	/* By-name loads reach the native ALC without any managed VerifyIsAlive gate (unlike the
-+	 * path/stream entry points), so reject a torn-down context here before the request
-+	 * touches state mono_alc_cleanup already destroyed. See mono_alc_reject_if_torn_down. */
-+	if (mono_alc_reject_if_torn_down (alc, error))
-+		goto fail;
-+
- 	mono_assembly_request_prepare_byname (&req, alc);
- 	req.basedir = NULL;
- 	/* Everything currently goes through this function, and the postload hook (aka the AppDomain.AssemblyResolve event)
 diff --git a/src/mono/mono/metadata/assembly-load-context.c b/src/mono/mono/metadata/assembly-load-context.c
-index d8eac6e34..aae388735 100644
+index d8eac6e34..a47a5ef03 100644
 --- a/src/mono/mono/metadata/assembly-load-context.c
 +++ b/src/mono/mono/metadata/assembly-load-context.c
-@@ -80,6 +80,10 @@ alcs_unlock (void)
+@@ -9,6 +9,7 @@
+ #include "mono/metadata/icall-decl.h"
+ #include "mono/metadata/loader-internals.h"
+ #include "mono/metadata/loaded-images-internals.h"
++#include "mono/metadata/object-internals.h"
+ #include "mono/metadata/mono-private-unstable.h"
+ #include "mono/metadata/mono-debug.h"
+ #include "mono/metadata/weak-hash.h"
+@@ -80,6 +81,17 @@ alcs_unlock (void)
  static GPtrArray *retired_scout_targets;
  /* Monotonic count of scouts given a terminal (TRUE) Destroy outcome; diagnostics only. */
  static gint32 retired_scout_terminal_count;
@@ -539,10 +586,26 @@ index d8eac6e34..aae388735 100644
 + * the last LoaderAllocator witness ran mono_alc_cleanup because the whole set was already
 + * quiescent); diagnostics only, exposed as kind 7 of InternalGetScoutRetirementStats. */
 +static gint32 scout_completed_teardown_count;
++/* Live-population ledger for the native MonoAssemblyLoadContext structs of collectible
++ * (opted-in) contexts: incremented when mono_alc_init honours the collectible request,
++ * decremented by mono_alc_free — the single free site for both teardown initiators (the
++ * forced attempt and the scout completion). Exposed as kind 9: any teardown path that
++ * loses a struct (the orphaned-tombstone class of bug) shows up as a value that fails to
++ * drain back to its baseline across load/unload cycles. Diagnostics only. */
++static gint32 collectible_alc_native_structs;
  
  static void
  retired_scout_targets_add (MonoMemoryManager *memory_manager)
-@@ -320,16 +324,18 @@ mono_alc_cleanup (MonoAssemblyLoadContext *alc)
+@@ -130,6 +142,8 @@ mono_alc_init (MonoAssemblyLoadContext *alc, gboolean collectible)
+ 	}
+ 	if (!native_alc_unload_enabled)
+ 		collectible = FALSE;
++	if (collectible)
++		collectible_alc_native_structs++;
+ #else
+ 	collectible = FALSE;
+ #endif
+@@ -320,16 +334,18 @@ mono_alc_cleanup (MonoAssemblyLoadContext *alc)
  	 * whole feature is hard-gated at compile time to the single-threaded browser build
  	 * (DISABLE_THREADS): on a threads-enabled runtime InternalForceNativeUnload rejects
  	 * up front and mono_alc_init never honours the collectible opt-in, so this function
@@ -566,7 +629,19 @@ index d8eac6e34..aae388735 100644
  	 */
  #ifdef DISABLE_THREADS
  	mono_loader_lock ();
-@@ -464,13 +470,67 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_PrepareForAssemblyLoadContex
+@@ -380,6 +396,11 @@ mono_alc_free (MonoAssemblyLoadContext *alc)
+ {
+ 	mono_alc_cleanup (alc);
+ 	g_free (alc);
++#ifdef DISABLE_THREADS
++	/* Ledger for stats kind 9; this is the single free site for both teardown initiators
++	 * (forced attempt and scout completion), and only collectible structs were counted. */
++	collectible_alc_native_structs--;
++#endif
+ }
+ 
+ void
+@@ -464,13 +485,68 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_PrepareForAssemblyLoadContex
  	mono_alc_memory_managers_unlock (alc);
  }
  
@@ -628,17 +703,19 @@ index d8eac6e34..aae388735 100644
  	 * bridge maps to AssemblyLoadContext.ForceNativeUnloadResult:
 -	 *   0 = Completed     — the ALC was torn down and freed.
 +	 *   0 = Completed     — the teardown ran to completion: every memory manager, loaded
-+	 *                       image and GC handle was released. When this call performs the
-+	 *                       teardown it also frees the ALC struct; when the GC-driven scout
-+	 *                       completion performed it earlier, the struct was kept as a
-+	 *                       tombstone and this call reports the state idempotently.
++	 *                       image, GC handle AND the ALC struct itself were freed. (When
++	 *                       the GC-driven scout completion performed the teardown earlier,
++	 *                       it also latched the managed wrapper to its terminal state, so a
++	 *                       host retry is answered Completed by the wrapper's claim CAS and
++	 *                       never reaches this icall with the freed pointer.)
  	 *   1 = NotQuiescent  — managed roots to the ALC still exist; nothing freed, retry later.
  	 *   2 = Rejected      — feature unavailable (threads-enabled build), or null / default /
  	 *                       non-collectible / not-yet-unloading ALC.
-@@ -505,45 +565,27 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
+@@ -504,46 +580,7 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
+ 	if (!alc->unloading)
  		return FORCE_UNLOAD_REJECTED;
  
- 	/*
+-	/*
 -	 * Quiescence gate — ALL-OR-NOTHING over the exact set of managers the teardown will
 -	 * free. alc->unloading only means the managed Unload() was requested — it is NOT proof
 -	 * that the collectible LoaderAllocators have been collected. Stack frames,
@@ -648,13 +725,7 @@ index d8eac6e34..aae388735 100644
 -	 * a manager's weak-handle target is non-NULL, managed roots remain and freeing would
 -	 * reclaim live memory. This is exactly the criterion the (disabled)
 -	 * LoaderAllocatorScout uses.
-+	 * Idempotent completion: the GC-driven scout path (LoaderAllocatorScout_Destroy below)
-+	 * may have already torn this ALC down after the host's roots died — a downstream WASM
-+	 * host doing repeated collectible-ALC load/unload cycles is not required to keep
-+	 * retrying a NotQuiescent attempt for the reclamation to happen. Everything material
-+	 * was freed by mono_alc_cleanup then; only this struct remained as the tombstone (see
-+	 * native_tombstoned in loader-internals.h), so report Completed.
- 	 *
+-	 *
 -	 * Every shared/generic memory manager has its OWN LoaderAllocator witness: a live
 -	 * cross-context constructed generic (e.g. an instance whose vtable lives in a shared
 -	 * {default, this} manager) keeps that shared witness alive even after the primary
@@ -664,14 +735,7 @@ index d8eac6e34..aae388735 100644
 -	 * NotQuiescent so the host retries after another GC rather than losing its single
 -	 * chance. A NULL weak handle means no LoaderAllocator bookkeeping was ever materialised
 -	 * for that manager (no vtable/object of it ever existed), which is safe to free.
-+	 * And reclaim the tombstone itself: this retry is provably the LAST carrier of the raw
-+	 * struct pointer. The cleanup already released every other native reference (global
-+	 * alcs-list membership, images, managers, name, gchandle), and on Completed the managed
-+	 * wrapper zeroes its _nativeAssemblyLoadContext and latches the terminal claim, whose
-+	 * CAS short-circuits every later ForceNativeUnload call before it can reach this icall.
-+	 * Only hosts that NEVER retry keep the ~100-byte struct per unloaded context — the
-+	 * documented, bounded residual of the scout-completed path.
- 	 */
+-	 */
 -	MonoMemoryManager *primary_mm = alc->memory_manager;
 -	if (primary_mm && primary_mm->loader_allocator_weak_handle &&
 -			mono_gchandle_get_target_internal (primary_mm->loader_allocator_weak_handle) != NULL)
@@ -688,18 +752,14 @@ index d8eac6e34..aae388735 100644
 -			witness_live = TRUE;
 -			break;
 -		}
-+	if (alc->native_tombstoned) {
-+		g_free (alc);
-+		return FORCE_UNLOAD_COMPLETED;
- 	}
+-	}
 -	mono_alc_memory_managers_unlock (alc);
 -	if (witness_live)
-+
 +	if (!alc_is_managed_quiescent (alc))
  		return FORCE_UNLOAD_NOT_QUIESCENT;
  
  	mono_alc_free (alc);
-@@ -593,6 +635,19 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+@@ -593,6 +630,28 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
  	 * mono_weak_hash_table_dead_lookup_count). Unconditional like kinds 2/3/5. A lifecycle test
  	 * uses it to prove the global assembly enumeration really took the terminal dead-cache path
  	 * for a condemned assembly (skipping it) instead of passing vacuously.
@@ -710,16 +770,25 @@ index d8eac6e34..aae388735 100644
 +	 * dropped every root without retrying a NotQuiescent forced attempt was really reclaimed
 +	 * by the scout finalizer rather than by a forced attempt.
 +	 *
-+	 * Kind 8 — GAUGE (not monotonic): collectible, unloading, not-yet-torn-down ALCs still
-+	 * on the global list — unloads whose teardown has not completed yet. Behind the
-+	 * DISABLE_THREADS gate like kinds 0/1. A witness that never dies would otherwise be
-+	 * observable only as silent infinite scout re-registration, indistinguishable from the
-+	 * pre-fix strand; this gauge makes it visible, and the lifecycle tests assert it drains
-+	 * back to 0 after every cycle.
++	 * Kind 8 — GAUGE (not monotonic): collectible, unloading ALCs still on the global list —
++	 * unloads whose teardown has not completed yet (a completed teardown unlinks the ALC).
++	 * Behind the DISABLE_THREADS gate like kinds 0/1. A witness that never dies would
++	 * otherwise be observable only as silent infinite scout re-registration,
++	 * indistinguishable from the pre-fix strand; this gauge makes it visible, and the
++	 * lifecycle tests assert it drains back to 0 after every cycle.
++	 *
++	 * Kind 9 — GAUGE (not monotonic): native MonoAssemblyLoadContext structs of collectible
++	 * (opted-in) contexts currently allocated (see collectible_alc_native_structs). Behind
++	 * the DISABLE_THREADS gate like kinds 0/1. Incremented at creation, decremented at the
++	 * single free site (mono_alc_free) shared by the forced attempt and the scout
++	 * completion, so ANY teardown path that loses a struct shows up as a value that fails
++	 * to drain back to its baseline across load/unload cycles — the orphaned-struct class
++	 * of bug, which kind 8 cannot see (an orphan is off the global list). The repeated
++	 * no-retry lifecycle test asserts the exact baseline return.
  	 */
  	if (kind == 2 || kind == 3)
  		return mono_weak_hash_table_key_value_handle_stats (kind - 2);
-@@ -611,6 +666,19 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+@@ -611,6 +670,21 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
  		return retired_scout_terminal_count;
  	case 4:
  		return mono_mem_manager_alc_unload_test_gc_hook_count ();
@@ -730,69 +799,77 @@ index d8eac6e34..aae388735 100644
 +		alcs_lock ();
 +		for (GSList *tmp = alcs; tmp; tmp = tmp->next) {
 +			MonoAssemblyLoadContext *a = (MonoAssemblyLoadContext *)tmp->data;
-+			if (a && a->collectible && a->unloading && !a->native_tombstoned)
++			if (a && a->collectible && a->unloading)
 +				pending++;
 +		}
 +		alcs_unlock ();
 +		return pending;
 +	}
++	case 9:
++		return collectible_alc_native_structs;
  	default:
  		return -1;
  	}
-@@ -768,12 +836,43 @@ leave:
- 	HANDLE_FUNCTION_RETURN_VAL (ass);
+@@ -1092,13 +1166,68 @@ mono_alc_get_all (void)
+ 	return all_alcs;
  }
  
++#ifdef DISABLE_THREADS
 +/*
-+ * Guard for icalls that receive a raw native ALC pointer from the managed wrapper. After
-+ * the GC-driven scout completion tore an ALC down (native_tombstoned), the surviving
-+ * managed wrapper still carries the raw pointer and its terminal claim is only latched by
-+ * a later ForceNativeUnload retry — so an ordinary load API called in that window would
-+ * otherwise walk straight into state mono_alc_cleanup already destroyed (assemblies_lock,
-+ * loaded_images, ...): a use-after-destroy, not an exception. Reading the flag here is
-+ * safe by construction: the tombstoned struct is freed only by the claim-gated retry, and
-+ * once that claim is latched the managed NativeALC getter rejects every consumer before
-+ * the pointer can reach an icall again.
++ * Latch the surviving managed AssemblyLoadContext wrapper to its terminal disposed state
++ * from the scout completion, BEFORE mono_alc_free releases the strong gchandle that is
++ * currently rooting it. This writes the same two fields the managed ForceNativeUnload
++ * path writes on Completed, in the same order:
++ *   _nativeAssemblyLoadContext = 0  (zeroed FIRST, so no reader can observe a terminal
++ *                                    claim together with a live-looking pointer)
++ *   _nativeUnloadForced        = 2  (the terminal claim; its CAS answers any later
++ *                                    ForceNativeUnload retry with Completed before the
++ *                                    icall can be reached)
++ * after which the NativeALC getter rejects every ordinary consumer, so freeing the native
++ * struct outright is safe: nothing can carry the pointer into native code again.
 + *
-+ * The reject surfaces as InvalidOperationException with the unloading-contract semantics
-+ * of the managed entry points (LoadFromAssemblyPath/LoadFromStream VerifyIsAlive-throw the
-+ * same for ANY unloading state upstream and here). Loads into an unloading-but-not-yet-
-+ * torn-down context intentionally keep working: the native side is fully functional
-+ * there, and upstream also services cached by-name resolves during the unloading window —
-+ * a blanket managed unloading guard on the by-name path would break exactly that.
++ * Safety of the mechanics:
++ *   - The wrapper CANNOT be dead here: the strong gchandle Prepare installed is exactly
++ *     what mono_alc_cleanup is about to release, so the target is still rooted.
++ *   - Both fields are unmanaged scalars (an IntPtr and an int32) — no reference writes,
++ *     so no write-barrier concerns; mono_field_set_value_internal on instance scalar
++ *     fields is a plain store. The wrapper may be a host subclass;
++ *     mono_class_get_field_from_name_full walks the parent chain to the declaring class.
++ *   - No reader can hold a pre-latch pointer across this run: on the single-threaded
++ *     browser runtime, finalizers execute as scheduled event-loop jobs — never mid-icall
++ *     and never between a NativeALC read and the icall it feeds within one synchronous
++ *     managed statement — and a ForceNativeUnload attempt can likewise never be in
++ *     flight (claim == 1) while a finalizer runs.
 + */
-+gboolean
-+mono_alc_reject_if_torn_down (MonoAssemblyLoadContext *alc, MonoError *error)
++static void
++scout_latch_managed_wrapper (MonoAssemblyLoadContext *alc)
 +{
-+	if (alc && alc->native_tombstoned) {
-+		mono_error_set_invalid_operation (error, "Cannot use a collectible AssemblyLoadContext whose unload has already completed.");
-+		return TRUE;
++	static MonoClassField *pointer_field;
++	static MonoClassField *claim_field;
++
++	MonoObject *wrapper = mono_gchandle_get_target_internal (alc->gchandle);
++	g_assert (wrapper); /* strong handle — released only by the cleanup that follows */
++
++	if (!pointer_field || !claim_field) {
++		/* Cache on the declaring class: field lookup walks parents, and the resolved
++		 * MonoClassField of System.Runtime.Loader.AssemblyLoadContext is the same for
++		 * every subclass instance. */
++		MonoClass *klass = mono_object_class (wrapper);
++		pointer_field = mono_class_get_field_from_name_full (klass, "_nativeAssemblyLoadContext", NULL);
++		claim_field = mono_class_get_field_from_name_full (klass, "_nativeUnloadForced", NULL);
++		g_assert (pointer_field);
++		g_assert (claim_field);
 +	}
-+	return FALSE;
++
++	gpointer zero = NULL;
++	mono_field_set_value_internal (wrapper, pointer_field, &zero);
++	gint32 completed = 2; /* ForceNativeUnloadResult claim: terminal (see the managed wrapper) */
++	mono_field_set_value_internal (wrapper, claim_field, &completed);
 +}
++#endif /* DISABLE_THREADS */
 +
- MonoReflectionAssemblyHandle
- ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalLoadFile (gpointer alc_ptr, MonoStringHandle fname, MonoStackCrawlMark *stack_mark, MonoError *error)
- {
- 	MonoReflectionAssemblyHandle result = MONO_HANDLE_CAST (MonoReflectionAssembly, NULL_HANDLE);
- 	MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)alc_ptr;
- 
-+	if (mono_alc_reject_if_torn_down (alc, error))
-+		goto leave;
-+
- 	MonoAssembly *executing_assembly;
- 	executing_assembly = mono_runtime_get_caller_from_stack_mark (stack_mark);
- 	MonoAssembly *ass = mono_alc_load_file (alc, fname, executing_assembly, !mono_alc_is_default (alc), error);
-@@ -823,6 +922,8 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalLoadFromStream (gpoi
- 	MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)native_alc;
- 	MonoReflectionAssemblyHandle result = MONO_HANDLE_CAST (MonoReflectionAssembly, NULL_HANDLE);
- 	MonoAssembly *assm = NULL;
-+	if (mono_alc_reject_if_torn_down (alc, error))
-+		goto leave;
- 	assm = mono_alc_load_raw_bytes (alc, (guint8 *)raw_assembly_ptr, raw_assembly_len, (guint8 *)raw_symbols_ptr, raw_symbols_len, error);
- 	goto_if_nok (error, leave);
- 
-@@ -1097,8 +1198,9 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
+ MonoBoolean
+ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
  {
  #ifdef DISABLE_THREADS
  	/*
@@ -804,7 +881,7 @@ index d8eac6e34..aae388735 100644
  	 * The consult is a pure pointer-value comparison — the freed manager is NEVER
  	 * dereferenced — and consuming the entry retires exactly one scout: it returns TRUE,
  	 * so the finalizer does not GC.ReRegisterForFinalize and the scout population stays
-@@ -1109,6 +1211,67 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
+@@ -1109,6 +1238,77 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
  		retired_scout_terminal_count++;
  		return TRUE;
  	}
@@ -823,10 +900,9 @@ index d8eac6e34..aae388735 100644
 +	 * strong alc->gchandle installed by PrepareForAssemblyLoadContextRelease is released
 +	 * only by mono_alc_cleanup, and before this path existed only a Completed forced
 +	 * attempt ever ran it. Now the last witness's finalizer runs the SAME all-or-nothing
-+	 * quiescence gate and the SAME cleanup; the struct itself is kept as a tiny tombstone
-+	 * (native_tombstoned) so a host that still holds the managed ALC and retries later
-+	 * gets an idempotent Completed instead of a use-after-free (see
-+	 * InternalForceNativeUnload above).
++	 * quiescence gate and the SAME teardown, after latching the surviving managed wrapper
++	 * to its terminal state (see scout_latch_managed_wrapper above) so the outright free
++	 * of the struct is safe and leaves no native residue.
 +	 *
 +	 * Single-threaded by construction (finalizers and icalls share the one thread), so
 +	 * this cannot interleave with a managed forced attempt; collectible is only ever TRUE
@@ -844,7 +920,7 @@ index d8eac6e34..aae388735 100644
 +	MonoAssemblyLoadContext *condemned = NULL;
 +	for (int i = 0; i < mm->n_alcs; ++i) {
 +		MonoAssemblyLoadContext *owner = mm->alcs [i];
-+		if (!owner || !owner->collectible || !owner->unloading || owner->native_tombstoned)
++		if (!owner || !owner->collectible || !owner->unloading)
 +			continue;
 +		if (!alc_is_managed_quiescent (owner))
 +			continue;
@@ -852,11 +928,22 @@ index d8eac6e34..aae388735 100644
 +		break;
 +	}
 +	if (condemned) {
-+		mono_alc_cleanup (condemned);
-+		condemned->native_tombstoned = TRUE;
++		/*
++		 * Latch the surviving managed wrapper to its terminal disposed state FIRST, then
++		 * free the native side outright — the scout completion leaves NO native residue
++		 * and needs no host cooperation to finish the job (an earlier revision kept the
++		 * struct as a tombstone for a possible host retry, but a host that never retries
++		 * would then leak one struct per cycle, unbounded). The latch is what makes the
++		 * outright free safe: with the wrapper's pointer zeroed and its claim terminal,
++		 * no managed consumer can ever carry the freed pointer into an icall again (the
++		 * NativeALC getter rejects on either signal, and ForceNativeUnload's claim CAS
++		 * short-circuits to Completed before reaching native).
++		 */
++		scout_latch_managed_wrapper (condemned);
++		mono_alc_free (condemned);
 +		scout_completed_teardown_count++;
 +		/*
-+		 * The cleanup freed this scout's own manager and registered it (with every other
++		 * The teardown freed this scout's own manager and registered it (with every other
 +		 * materialised manager of the ALC) in the retired registry, so consume the entry
 +		 * now for the terminal outcome instead of waiting for a pointless extra
 +		 * finalization round. The consume MUST succeed: this scout exists, so its
@@ -872,37 +959,6 @@ index d8eac6e34..aae388735 100644
  #endif
  
  	/* Not enabled yet */
-diff --git a/src/mono/mono/metadata/loader-internals.h b/src/mono/mono/metadata/loader-internals.h
-index 4275a39d2..aef5e44ae 100644
---- a/src/mono/mono/metadata/loader-internals.h
-+++ b/src/mono/mono/metadata/loader-internals.h
-@@ -107,6 +107,13 @@ struct _MonoAssemblyLoadContext {
- 	gboolean collectible;
- 	// Set to TRUE when the unloading process has begun
- 	gboolean unloading;
-+	// Set to TRUE when the GC-driven scout completion (LoaderAllocatorScout_Destroy) has
-+	// already run mono_alc_cleanup for this ALC. Everything material is freed; only this
-+	// struct remains, kept as a tiny tombstone so a host that still holds the managed ALC
-+	// and calls ForceNativeUnload afterwards gets an idempotent Completed instead of
-+	// dereferencing freed storage. Only meaningful for collectible ALCs under the
-+	// MONO_WASM_ENABLE_ALC_UNLOAD opt-in on the single-threaded browser build.
-+	gboolean native_tombstoned;
- 	// Used in native-library.c for the hash table below; do not access anywhere else
- 	MonoCoopMutex pinvoke_lock;
- 	// Maps malloc-ed char* pinvoke scope -> MonoDl*
-@@ -236,6 +243,12 @@ mono_alc_memory_managers_unlock (MonoAssemblyLoadContext *alc);
- gboolean
- mono_alc_is_default (MonoAssemblyLoadContext *alc);
- 
-+/* Sets InvalidOperationException on `error` and returns TRUE when the ALC was already torn
-+ * down by the GC-driven scout completion (native_tombstoned): icalls receiving a raw native
-+ * ALC pointer must reject before dereferencing state mono_alc_cleanup destroyed. */
-+gboolean
-+mono_alc_reject_if_torn_down (MonoAssemblyLoadContext *alc, MonoError *error);
-+
- MonoAssembly*
- mono_alc_invoke_resolve_using_load_nofail (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname);
- 
 -- 
 2.53.0.vfs.0.0
 

--- a/patches/0013-gc-driven-scout-completion-for-forced-alc-unload.patch
+++ b/patches/0013-gc-driven-scout-completion-for-forced-alc-unload.patch
@@ -34,10 +34,12 @@ CoreCLR LoaderAllocatorScout design:
   * LoaderAllocatorScout_Destroy (the scout finalizer icall, previously
     terminal-registry-consult-only on this runtime) now completes the
     teardown itself: when the finalizing scout's memory manager belongs
-    to a collectible, unloading, not-yet-torn-down ALC whose WHOLE
+    to a collectible, unloading ALC whose WHOLE
     witness set is dead -- the same all-or-nothing quiescence gate the
     forced attempt uses, factored into alc_is_managed_quiescent -- it
-    runs mono_alc_cleanup right there. The last witness's finalizer is
+    runs the same teardown right there (mono_alc_free, so
+    mono_alc_cleanup keeps a single caller reached from two gated
+    initiators). The last witness's finalizer is
     by definition the first moment this can succeed, and the finalizer
     pump runs after exactly the collection that killed the roots, so
     plain GC now reclaims the managed ALC with no host retry. If the
@@ -78,7 +80,14 @@ CoreCLR LoaderAllocatorScout design:
     working: the native side is fully functional there, and upstream
     also services cached by-name resolves during the unloading window
     (the path/stream entry points VerifyIsAlive-reject there, upstream
-    and here alike).
+    and here alike). That window now ends SPONTANEOUSLY under the
+    opt-in: the scout completion runs at a GC-chosen moment with no
+    host action, after which ordinary load APIs throw
+    ObjectDisposedException on a context the host still holds -- a
+    deliberate, documented divergence from flag-off/upstream behavior
+    (where nothing ever completes the unload), stated on
+    ForceNativeUnload's own documentation as the host-visible
+    contract.
   * No zero-witness hole: every opted-in collectible ALC eagerly
     materialises its primary LoaderAllocator -- and therefore a scout
     and a weak witness -- at creation (mono_alc_init calls
@@ -173,16 +182,31 @@ New lifecycle tests:
 
 Refs https://github.com/unoplatform/Uno.DotnetRuntime.WebAssembly/issues/169.
 ---
- .../tests/ForcedNativeUnloadTests.cs          | 417 +++++++++++++++++-
- .../Loader/AssemblyLoadContext.Mono.cs        |  24 +-
- .../mono/metadata/assembly-load-context.c     | 312 +++++++++++--
- 3 files changed, 703 insertions(+), 50 deletions(-)
+ .../Runtime/Loader/AssemblyLoadContext.cs     |   3 +
+ .../tests/ForcedNativeUnloadTests.cs          | 430 +++++++++++++++++-
+ .../Loader/AssemblyLoadContext.Mono.cs        |  42 +-
+ .../mono/metadata/assembly-load-context.c     | 331 ++++++++++++--
+ 4 files changed, 756 insertions(+), 50 deletions(-)
 
+diff --git a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+index 4eac33a24..01b5f1f7a 100644
+--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
++++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+@@ -48,6 +48,9 @@ private enum InternalState
+         // Not readonly: the Mono host-triggered forced native unload (ForceNativeUnload in
+         // AssemblyLoadContext.Mono.cs) tombstones it to IntPtr.Zero once the native side has
+         // been freed, so no managed path can forward the stale pointer to an icall.
++        // Second writer: the Mono native scout completion (scout_latch_managed_wrapper in
++        // assembly-load-context.c) zeroes this directly BEFORE setting the _nativeUnloadForced
++        // claim terminal — that store order is load-bearing.
+         private IntPtr _nativeAssemblyLoadContext;
+ #endregion
+ 
 diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
-index 60708a1b5..0781e05f9 100644
+index 60708a1b5..a338595e1 100644
 --- a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 +++ b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
-@@ -78,6 +78,17 @@ public class ForcedNativeUnloadTests
+@@ -78,6 +78,20 @@ public class ForcedNativeUnloadTests
          // manager's LoaderAllocator; mono_weak_hash_table_dead_lookup_count). Unconditional
          // shared-runtime code, like kinds 2/3/5.
          private const int WeakTableDeadLookupCount = 6;
@@ -197,10 +221,13 @@ index 60708a1b5..0781e05f9 100644
 +        // (creation/free ledger). Catches the orphaned-struct class of bug kind 8 cannot see —
 +        // an orphan is off the global list — by failing to drain back to its baseline.
 +        private const int NativeStructsGauge = 9;
++        // Monotonic: scout finalizer ran but completed nothing and re-registered. Distinguishes
++        // "ran and refused" from "never ran" (a never-dying witness climbs this, kind 7 flat).
++        private const int ScoutCompletionDeferralCount = 10;
  
          private static readonly MethodInfo s_forceNativeUnload = typeof(AssemblyLoadContext)
              .GetMethod("ForceNativeUnload", BindingFlags.NonPublic | BindingFlags.Instance);
-@@ -269,6 +280,301 @@ public async Task ForcedUnload_OnlyCompletesOnceQuiescent()
+@@ -269,6 +283,323 @@ public async Task ForcedUnload_OnlyCompletesOnceQuiescent()
              }
          }
  
@@ -292,9 +319,8 @@ index 60708a1b5..0781e05f9 100644
 +        ///     claim CAS without entering the icall at all.
 +        /// "Zero residual" means: the scout registry drains, the pending-unloads gauge returns
 +        /// to 0, and the native-struct ledger (kind 9) returns to its pre-test baseline —
-+        /// nothing native survives the cycle. (Unlike the two strand regressions above, parts
-+        /// of this test also pass on the pre-fix runtime: it guards the retry contract and the
-+        /// sealed post-completion surface, not the strand.)
++        /// nothing native survives the cycle. (Not a strand regression: it guards the retry
++        /// contract and the sealed post-completion surface.)
 +        /// </summary>
 +        [Fact]
 +        public async Task ForcedUnload_RetryAfterRootsDropped_CompletesWithZeroResidual()
@@ -378,7 +404,7 @@ index 60708a1b5..0781e05f9 100644
 +                return;
 +            }
 +
-+            int structsBefore = ScoutStats(NativeStructsGauge);
++            int structsBefore = ProtocolActive ? ScoutStats(NativeStructsGauge) : 0;
 +
 +            int scoutBeforeHiding = ProtocolActive ? ScoutStats(ScoutCompletedTeardownCount) : 0;
 +            var hiding = new FieldHidingAssemblyLoadContext();
@@ -435,13 +461,10 @@ index 60708a1b5..0781e05f9 100644
 +
 +        /// <summary>
 +        /// The no-retry residue regression: a host that never calls ForceNativeUnload at all —
-+        /// N load/unload/drop cycles — must leave NO native residue. An earlier revision kept
-+        /// the scout-completed ALC struct as a native tombstone whose only free site was a
-+        /// host retry, so a never-retrying host leaked one ~100-byte struct per cycle,
-+        /// unbounded over process lifetime, invisible to the pending-unloads gauge (an orphan
-+        /// is off the global list). The native-struct ledger (kind 9) counts creations against
-+        /// the single free site, so any teardown path that loses a struct fails the exact
-+        /// baseline-return assertion here.
++        /// N load/unload/drop cycles — must leave NO native residue. An orphaned struct is
++        /// invisible to the pending-unloads gauge (an orphan is off the global list); the
++        /// native-struct ledger (kind 9) counts creations against the single free site, so any
++        /// teardown path that loses a struct fails the exact baseline-return assertion here.
 +        /// </summary>
 +        [Fact]
 +        public async Task RepeatedUnloadWithoutRetry_NativeStructPopulationReturnsToBaseline()
@@ -452,7 +475,7 @@ index 60708a1b5..0781e05f9 100644
 +            }
 +
 +            const int Cycles = 5;
-+            int structsBefore = ScoutStats(NativeStructsGauge);
++            int structsBefore = ProtocolActive ? ScoutStats(NativeStructsGauge) : 0;
 +            int scoutCompletionsBefore = ProtocolActive ? ScoutStats(ScoutCompletedTeardownCount) : 0;
 +
 +            var refs = new WeakReference[Cycles];
@@ -467,16 +490,42 @@ index 60708a1b5..0781e05f9 100644
 +                    "every unloaded context must be reclaimed by plain GC without any forced attempt.");
 +            }
 +
-+            // The ledger must return exactly to its baseline: creations balanced by frees. On
-+            // the flag-off leg the gauge never moves (nothing is natively collectible) and on
-+            // the threads-enabled leg it reports -1 throughout, so the equality holds — and is
-+            // meaningful — on every leg.
-+            Assert.Equal(structsBefore, ScoutStats(NativeStructsGauge));
-+
 +            if (ProtocolActive)
 +            {
++                // The ledger must return exactly to its baseline: creations balanced by frees.
++                Assert.Equal(structsBefore, ScoutStats(NativeStructsGauge));
 +                Assert.Equal(scoutCompletionsBefore + Cycles, ScoutStats(ScoutCompletedTeardownCount));
 +                Assert.Equal(0, ScoutStats(PendingUnloadsGauge));
++
++                // Deferral observability (kind 10): build the one shape a scout cannot complete
++                // — an unloading context whose only live witness is the shared cross-context
++                // constructed-generic wrapper (its keepalive edge is the SHARED LoaderAllocator,
++                // so the primary witness dies alone; see CreateCrossTypeWitness) — and pump: the
++                // primary manager's scout must record a DEFERRAL rather than completing, making
++                // "ran and refused" observable. Then release the witness and drive both contexts
++                // terminal so the probe leaves no pending state behind.
++                var contextA = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
++                var contextB = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
++                object sharedWitness = CreateCrossTypeWitness(contextA, contextB);
++                contextA.Unload();
++
++                int deferralsBefore = ScoutStats(ScoutCompletionDeferralCount);
++                for (int attempt = 0; attempt < 20 && ScoutStats(ScoutCompletionDeferralCount) == deferralsBefore; attempt++)
++                {
++                    GcQuiesce();
++                    await Task.Delay(1);
++                }
++
++                Assert.True(ScoutStats(ScoutCompletionDeferralCount) > deferralsBefore,
++                    "a scout finalizing while another witness of its context's set is still alive must record a deferral (kind 10).");
++
++                GC.KeepAlive(sharedWitness);
++                sharedWitness = null;
++                Assert.Equal(Completed, await ForceUntilCompletedAsync(contextA, 10));
++                contextB.Unload();
++                Assert.Equal(Completed, await ForceUntilCompletedAsync(contextB, 10));
++                await DrainRetiredScoutsAsync();
++                Assert.Equal(structsBefore, ScoutStats(NativeStructsGauge));
 +            }
 +        }
 +
@@ -502,7 +551,7 @@ index 60708a1b5..0781e05f9 100644
          [Fact]
          public async Task ForcedUnload_RootedCrossContextGeneric_BlocksNativeFree()
          {
-@@ -936,6 +1242,29 @@ private static async Task RunRejectedCycles(int cycles)
+@@ -936,6 +1267,29 @@ private static async Task RunRejectedCycles(int cycles)
              }
          }
  
@@ -532,7 +581,7 @@ index 60708a1b5..0781e05f9 100644
          // Drive GC + finalization until the retired-scout set drains. Counter-based and bounded:
          // each pass collects (queueing/re-queueing any scouts whose LoaderAllocator is dead,
          // including ones that re-registered with FALSE on an earlier pass) and then lets finalizers
-@@ -966,6 +1295,91 @@ private static async Task DrainRetiredScoutsAsync()
+@@ -966,6 +1320,79 @@ private static async Task DrainRetiredScoutsAsync()
              Assert.Equal(0, ScoutStats(RetiredSetSize));
          }
  
@@ -546,6 +595,32 @@ index 60708a1b5..0781e05f9 100644
 +        {
 +            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
 +            var weakRef = new WeakReference(context);
++            FirstAttemptOnRootedContext(context);
++            GC.KeepAlive(context);
++            return weakRef;
++        }
++
++        // Same confinement discipline, without any forced attempt anywhere.
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static WeakReference LoadRootUnloadAndDrop()
++        {
++            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
++            var weakRef = new WeakReference(context);
++            object root = LoadUnloadReturningRootedInstance(context);
++
++            Assert.NotNull(root.ToString());
++
++            GC.KeepAlive(root);
++            GC.KeepAlive(context);
++            return weakRef;
++        }
++
++        // First (refused) attempt on a still-rooted context, with the root confined to this
++        // frame; callers keep only the context reference (for a later retry) or a
++        // WeakReference (for reclamation assertions).
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static void FirstAttemptOnRootedContext(AssemblyLoadContext context)
++        {
 +            object root = LoadUnloadReturningRootedInstance(context);
 +
 +            GcQuiesce();
@@ -567,44 +642,6 @@ index 60708a1b5..0781e05f9 100644
 +            Assert.NotNull(root.ToString());
 +
 +            GC.KeepAlive(root);
-+            GC.KeepAlive(context);
-+            return weakRef;
-+        }
-+
-+        // Same confinement discipline, without any forced attempt anywhere.
-+        [MethodImpl(MethodImplOptions.NoInlining)]
-+        private static WeakReference LoadRootUnloadAndDrop()
-+        {
-+            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
-+            var weakRef = new WeakReference(context);
-+            object root = LoadUnloadReturningRootedInstance(context);
-+
-+            Assert.NotNull(root.ToString());
-+
-+            GC.KeepAlive(root);
-+            GC.KeepAlive(context);
-+            return weakRef;
-+        }
-+
-+        // First (refused) attempt on a still-rooted context, with the root confined to this
-+        // frame; the caller keeps only the context reference for its later retry.
-+        [MethodImpl(MethodImplOptions.NoInlining)]
-+        private static void FirstAttemptOnRootedContext(AssemblyLoadContext context)
-+        {
-+            object root = LoadUnloadReturningRootedInstance(context);
-+
-+            GcQuiesce();
-+            int outcome = Force(context);
-+            if (ProtocolActive)
-+            {
-+                Assert.Equal(NotQuiescent, outcome);
-+            }
-+            else
-+            {
-+                Assert.Equal(Rejected, outcome);
-+            }
-+
-+            GC.KeepAlive(root);
 +        }
 +
 +        // Loads the collectible test assembly, instantiates a type from it (the managed root
@@ -624,7 +661,7 @@ index 60708a1b5..0781e05f9 100644
          [MethodImpl(MethodImplOptions.NoInlining)]
          private static async Task<WeakReference> LoadExerciseUnloadAndForce()
          {
-@@ -1554,7 +1968,8 @@ private static void Churn(int rounds)
+@@ -1554,7 +1981,8 @@ private static void Churn(int rounds)
          // Holding asm/type/list in THIS frame across the force would keep the primary and
          // shared-generic LoaderAllocator witnesses alive and pin the force at NotQuiescent. Only
          // the ALC object itself lives here, which is safe: the runtime holds a strong handle to
@@ -635,10 +672,10 @@ index 60708a1b5..0781e05f9 100644
          private static async Task ReflectionHashInitUnderPressureCycle(int seed)
          {
 diff --git a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
-index 88ce94a0c..7bbf6a7d1 100644
+index 88ce94a0c..ca1b6ff47 100644
 --- a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
 +++ b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
-@@ -78,6 +78,21 @@ private static void KeepLoaderAllocator()
+@@ -78,6 +78,25 @@ private static void KeepLoaderAllocator()
          // cycles rather than growing by three per reflection-using memory manager. Unlike kinds
          // 0/1 these are available on every build, because the ownership fix they observe is
          // unconditional (not part of the DISABLE_THREADS-gated forced teardown).
@@ -657,10 +694,14 @@ index 88ce94a0c..7bbf6a7d1 100644
 +        // currently allocated (creation/free ledger). Any teardown path that loses a struct —
 +        // which kind 8 cannot see, an orphan being off the global list — fails to drain this
 +        // back to its baseline across load/unload cycles; tests assert the exact return.
++        //
++        // Kind 10 counts scout-completion DEFERRALS (monotonic): the scout finalizer ran,
++        // completed nothing, and re-registered. Distinguishes "ran and refused" from "never
++        // ran" — a never-dying witness climbs this while kind 7 stays flat.
          internal static int GetScoutRetirementStats(int kind) => InternalGetScoutRetirementStats(kind);
  
          [MethodImplAttribute(MethodImplOptions.InternalCall)]
-@@ -119,7 +134,14 @@ internal static int RunJiterpreterTableSelfTest()
+@@ -119,7 +138,14 @@ internal static int RunJiterpreterTableSelfTest()
          // in the native assembly-load-context.c.
          internal enum ForceNativeUnloadResult
          {
@@ -676,8 +717,36 @@ index 88ce94a0c..7bbf6a7d1 100644
              Completed = 0,
              // The managed LoaderAllocator is still rooted (its weak handle target is non-NULL), so
              // freeing now would reclaim live memory. Nothing was freed; the caller should retry
+@@ -139,6 +165,11 @@ internal enum ForceNativeUnloadResult
+         // _nativeAssemblyLoadContext is tombstoned to IntPtr.Zero); on NotQuiescent/Rejected it is
+         // released back to 0 so a correct later call can re-enter. A concurrent caller that
+         // observes 1 backs off with NotQuiescent and never re-enters.
++        //
++        // Second writer: the native scout completion (scout_latch_managed_wrapper in
++        // assembly-load-context.c) stores 2 here directly when it finishes the teardown at a
++        // GC-chosen moment — after zeroing _nativeAssemblyLoadContext; that store order is
++        // load-bearing so no reader can observe a terminal claim with a live-looking pointer.
+         private int _nativeUnloadForced;
+ 
+         // Invoked by a downstream host once it has proven the collectible ALC is managed-quiescent.
+@@ -146,6 +177,15 @@ internal enum ForceNativeUnloadResult
+         // idempotent no-op; on NotQuiescent/Rejected nothing was freed and a later call will re-run
+         // the native validation. The native icall guards null/default/non-collectible/non-terminal
+         // state (Rejected) and proves GC quiescence via the LoaderAllocator weak handle (NotQuiescent).
++        //
++        // Spontaneous terminal window (opt-in only): the GC-driven scout completion can also
++        // finish the teardown at a GC-chosen moment with no host action, latching this instance
++        // terminal from native. From that moment ordinary load APIs throw
++        // ObjectDisposedException even though the host never observed a Completed return — a
++        // deliberate divergence from the flag-off/upstream behavior (where an unloading context
++        // keeps servicing cached by-name resolves indefinitely, because nothing ever completes
++        // the unload). Hosts holding a context past Unload() must treat it as disposable at any
++        // GC boundary once its roots are gone.
+         internal ForceNativeUnloadResult ForceNativeUnload()
+         {
+             // Claim the transition before touching the native ALC: 0 (idle) -> 1 (in-flight). Only
 diff --git a/src/mono/mono/metadata/assembly-load-context.c b/src/mono/mono/metadata/assembly-load-context.c
-index d8eac6e34..67cb51a0c 100644
+index d8eac6e34..065b4a4ac 100644
 --- a/src/mono/mono/metadata/assembly-load-context.c
 +++ b/src/mono/mono/metadata/assembly-load-context.c
 @@ -9,6 +9,7 @@
@@ -688,7 +757,7 @@ index d8eac6e34..67cb51a0c 100644
  #include "mono/metadata/mono-private-unstable.h"
  #include "mono/metadata/mono-debug.h"
  #include "mono/metadata/weak-hash.h"
-@@ -80,6 +81,17 @@ alcs_unlock (void)
+@@ -80,6 +81,24 @@ alcs_unlock (void)
  static GPtrArray *retired_scout_targets;
  /* Monotonic count of scouts given a terminal (TRUE) Destroy outcome; diagnostics only. */
  static gint32 retired_scout_terminal_count;
@@ -703,10 +772,17 @@ index d8eac6e34..67cb51a0c 100644
 + * loses a struct (the orphaned-tombstone class of bug) shows up as a value that fails to
 + * drain back to its baseline across load/unload cycles. Diagnostics only. */
 +static gint32 collectible_alc_native_structs;
++/* Monotonic count of scout-completion DEFERRALS: a scout finalizer consulted the GC-driven
++ * completion but could not complete any owner (no eligible owner, or another witness of the
++ * owner's set still alive) and re-registered for a later collection. Without this, "the
++ * scout ran and refused" is indistinguishable from "the scout never ran" — a witness that
++ * never dies shows up as this counter climbing while kind 7 stays flat. Exposed as kind 10
++ * of InternalGetScoutRetirementStats; diagnostics only. */
++static gint32 scout_completion_deferral_count;
  
  static void
  retired_scout_targets_add (MonoMemoryManager *memory_manager)
-@@ -130,6 +142,8 @@ mono_alc_init (MonoAssemblyLoadContext *alc, gboolean collectible)
+@@ -130,6 +149,8 @@ mono_alc_init (MonoAssemblyLoadContext *alc, gboolean collectible)
  	}
  	if (!native_alc_unload_enabled)
  		collectible = FALSE;
@@ -715,13 +791,14 @@ index d8eac6e34..67cb51a0c 100644
  #else
  	collectible = FALSE;
  #endif
-@@ -320,16 +334,18 @@ mono_alc_cleanup (MonoAssemblyLoadContext *alc)
+@@ -320,16 +341,19 @@ mono_alc_cleanup (MonoAssemblyLoadContext *alc)
  	 * whole feature is hard-gated at compile time to the single-threaded browser build
  	 * (DISABLE_THREADS): on a threads-enabled runtime InternalForceNativeUnload rejects
  	 * up front and mono_alc_init never honours the collectible opt-in, so this function
 -	 * is unreachable there (its only caller is mono_alc_free from the gated icall) and
-+	 * is unreachable there (its callers are mono_alc_free from the gated icall and the
-+	 * DISABLE_THREADS-gated scout completion in LoaderAllocatorScout_Destroy) and
++	 * is unreachable there (its only caller is still mono_alc_free, now reached from two
++	 * gated initiators: the forced-unload icall and the scout completion in
++	 * LoaderAllocatorScout_Destroy) and
  	 * no preparation (mono_mem_manager_start_unload) has mutated the shared managers.
  	 * Within the gate the loader lock brackets the whole sequence (matching the scout
  	 * protocol) and is correctly ordered above the per-owner memory_managers_lock
@@ -739,7 +816,7 @@ index d8eac6e34..67cb51a0c 100644
  	 */
  #ifdef DISABLE_THREADS
  	mono_loader_lock ();
-@@ -380,6 +396,11 @@ mono_alc_free (MonoAssemblyLoadContext *alc)
+@@ -380,6 +404,11 @@ mono_alc_free (MonoAssemblyLoadContext *alc)
  {
  	mono_alc_cleanup (alc);
  	g_free (alc);
@@ -751,7 +828,7 @@ index d8eac6e34..67cb51a0c 100644
  }
  
  void
-@@ -464,13 +485,68 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_PrepareForAssemblyLoadContex
+@@ -464,13 +493,68 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_PrepareForAssemblyLoadContex
  	mono_alc_memory_managers_unlock (alc);
  }
  
@@ -821,7 +898,7 @@ index d8eac6e34..67cb51a0c 100644
  	 *   1 = NotQuiescent  — managed roots to the ALC still exist; nothing freed, retry later.
  	 *   2 = Rejected      — feature unavailable (threads-enabled build), or null / default /
  	 *                       non-collectible / not-yet-unloading ALC.
-@@ -504,46 +580,7 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
+@@ -504,46 +588,7 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
  	if (!alc->unloading)
  		return FORCE_UNLOAD_REJECTED;
  
@@ -869,7 +946,7 @@ index d8eac6e34..67cb51a0c 100644
  		return FORCE_UNLOAD_NOT_QUIESCENT;
  
  	mono_alc_free (alc);
-@@ -593,6 +630,28 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+@@ -593,6 +638,34 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
  	 * mono_weak_hash_table_dead_lookup_count). Unconditional like kinds 2/3/5. A lifecycle test
  	 * uses it to prove the global assembly enumeration really took the terminal dead-cache path
  	 * for a condemned assembly (skipping it) instead of passing vacuously.
@@ -895,10 +972,16 @@ index d8eac6e34..67cb51a0c 100644
 +	 * to drain back to its baseline across load/unload cycles — the orphaned-struct class
 +	 * of bug, which kind 8 cannot see (an orphan is off the global list). The repeated
 +	 * no-retry lifecycle test asserts the exact baseline return.
++	 *
++	 * Kind 10 — monotonic count of scout-completion deferrals (see
++	 * scout_completion_deferral_count): the scout finalizer ran, completed nothing, and
++	 * re-registered. Behind the DISABLE_THREADS gate like kinds 0/1. Distinguishes "the
++	 * scout ran and refused" from "the scout never ran": a never-dying witness climbs this
++	 * counter while kind 7 stays flat.
  	 */
  	if (kind == 2 || kind == 3)
  		return mono_weak_hash_table_key_value_handle_stats (kind - 2);
-@@ -611,6 +670,21 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+@@ -611,6 +684,23 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
  		return retired_scout_terminal_count;
  	case 4:
  		return mono_mem_manager_alc_unload_test_gc_hook_count ();
@@ -917,10 +1000,12 @@ index d8eac6e34..67cb51a0c 100644
 +	}
 +	case 9:
 +		return collectible_alc_native_structs;
++	case 10:
++		return scout_completion_deferral_count;
  	default:
  		return -1;
  	}
-@@ -1092,13 +1166,84 @@ mono_alc_get_all (void)
+@@ -1092,13 +1182,84 @@ mono_alc_get_all (void)
  	return all_alcs;
  }
  
@@ -1007,7 +1092,7 @@ index d8eac6e34..67cb51a0c 100644
  	 * The consult is a pure pointer-value comparison — the freed manager is NEVER
  	 * dereferenced — and consuming the entry retires exactly one scout: it returns TRUE,
  	 * so the finalizer does not GC.ReRegisterForFinalize and the scout population stays
-@@ -1109,6 +1254,77 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
+@@ -1109,6 +1270,80 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
  		retired_scout_terminal_count++;
  		return TRUE;
  	}
@@ -1057,9 +1142,7 @@ index d8eac6e34..67cb51a0c 100644
 +		/*
 +		 * Latch the surviving managed wrapper to its terminal disposed state FIRST, then
 +		 * free the native side outright — the scout completion leaves NO native residue
-+		 * and needs no host cooperation to finish the job (an earlier revision kept the
-+		 * struct as a tombstone for a possible host retry, but a host that never retries
-+		 * would then leak one struct per cycle, unbounded). The latch is what makes the
++		 * and needs no host cooperation to finish the job. The latch is what makes the
 +		 * outright free safe: with the wrapper's pointer zeroed and its claim terminal,
 +		 * no managed consumer can ever carry the freed pointer into an icall again (the
 +		 * NativeALC getter rejects on either signal, and ForceNativeUnload's claim CAS
@@ -1078,10 +1161,15 @@ index d8eac6e34..67cb51a0c 100644
 +		 * of the registration sites cannot silently reopen a use-after-free window here.
 +		 */
 +		gboolean consumed = retired_scout_targets_consume (native);
-+		g_assert (consumed);
++		g_assertf (consumed, "scout completion freed manager %p but its retired-registry entry is missing", native);
 +		retired_scout_terminal_count++;
 +		return TRUE;
 +	}
++
++	/* The scout ran but completed nothing (no eligible owner, or another witness of the
++	 * owner's set is still alive): count the deferral so refusal is observable, then fall
++	 * through to FALSE and let the managed finalizer re-register for the next collection. */
++	scout_completion_deferral_count++;
  #endif
  
  	/* Not enabled yet */

--- a/patches/0013-gc-driven-scout-completion-for-forced-alc-unload.patch
+++ b/patches/0013-gc-driven-scout-completion-for-forced-alc-unload.patch
@@ -1,0 +1,643 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nick Randolph <noreply@platform.uno>
+Date: Wed, 12 Aug 2026 00:00:00 +0000
+Subject: [PATCH] fix: GC-driven scout completion so a refused forced unload
+ cannot strand the ALC
+
+A downstream WASM host doing repeated collectible-ALC load/unload
+cycles observed one disposed AssemblyLoadContext stranded per cycle
+(monotonic growth until native OOM) with the MONO_WASM_ENABLE_ALC_UNLOAD
+opt-in active, while the identical host wiring collected normally with
+the flag off. The host calls ForceNativeUnload once at teardown, while
+the context is still transiently rooted (in-flight worker state), gets
+NotQuiescent, then drops every root and moves on without retrying.
+
+Root cause -- NOT a per-attempt acquisition: the forced attempt itself
+is side-effect-free on both early-out paths (the icall takes no handle,
+no registration and no allocation before its quiescence walk, and the
+managed claim CAS is released on NotQuiescent/Rejected). The strand is
+older than the attempt: PrepareForAssemblyLoadContextRelease (managed
+Unload) swaps the native ALC handle from weak to STRONG to keep the
+managed context alive for the unloading window, and the ONLY release of
+that handle is mono_alc_cleanup -- which, until now, only a Completed
+forced attempt ever ran. With the flag off the ALC is natively
+non-collectible, Prepare takes the early return that frees the strong
+handle immediately, and the managed context dies with its roots; with
+the flag on, a host that never re-attempts leaves the managed context
+(and everything the host's ALC subclass instance references -- stream
+resolvers, assembly bytes) strongly rooted forever. One stranded
+context per cycle, exactly as observed.
+
+The fix gives the strong handle a GC-driven release, mirroring the
+CoreCLR LoaderAllocatorScout design:
+
+  * LoaderAllocatorScout_Destroy (the scout finalizer icall, previously
+    terminal-registry-consult-only on this runtime) now completes the
+    teardown itself: when the finalizing scout's memory manager belongs
+    to a collectible, unloading, not-yet-torn-down ALC whose WHOLE
+    witness set is dead -- the same all-or-nothing quiescence gate the
+    forced attempt uses, factored into alc_is_managed_quiescent -- it
+    runs mono_alc_cleanup right there. The last witness's finalizer is
+    by definition the first moment this can succeed, and the finalizer
+    pump runs after exactly the collection that killed the roots, so
+    plain GC now reclaims the managed ALC with no host retry. If the
+    set is not yet fully dead the scout re-registers for finalization
+    (the pre-existing managed retry loop) and tries again next GC.
+  * Tombstone, not free: the scout-driven path keeps the tiny
+    MonoAssemblyLoadContext struct alive with a new native_tombstoned
+    flag (loader-internals.h) instead of g_free-ing it, because a host
+    may still hold the managed context and legitimately retry
+    ForceNativeUnload later -- that retry carries the raw native
+    pointer, so freeing the struct would be a use-after-free. The
+    forced icall answers a tombstoned ALC with an idempotent Completed
+    (before its own quiescence walk), after which the managed wrapper
+    latches its terminal claim and zeroes the pointer exactly as if it
+    had performed the teardown. Managed load APIs were already rejected
+    from the moment Unload() was initiated, so nothing else can carry
+    the stale pointer into native code. The residual is ~one hundred
+    bytes per context, only on the scout-completed path, and bounded by
+    it (a Completed forced attempt still frees the struct as before).
+  * Ordering safety is inherited from the existing retired-scout
+    registry: scouts whose manager was freed by any teardown (forced or
+    scout-driven -- mono_alc_cleanup registers every materialised
+    manager) consume their registry entry at the TOP of Destroy and
+    never dereference the freed manager; a not-registered pointer is
+    provably a live manager. The owner scan runs before the cleanup
+    because the cleanup frees the scanning scout's own manager. All of
+    it single-threaded by construction (finalizers and icalls share the
+    one thread) and dark by default (collectible is only ever TRUE
+    under the opt-in).
+  * Diagnostics: scout-stats kind 7 counts scout-driven completions
+    (monotonic), so the tests can prove the reclaim went through the
+    scout path rather than passing vacuously -- under the opt-in the
+    strong handle makes ALC death impossible any other way, and the
+    stat pins it explicitly.
+
+New lifecycle regressions (red on the previous runtime for the flag-on
+leg, exactly like the field failure; green flag-off/threads):
+
+  * ForcedUnload_SingleNotQuiescentAttempt_ThenDroppedRoots_DoesNotStrandAlc
+    -- the reported shape: one refused attempt on a genuinely rooted
+    context, roots dropped, no retry; plain GC must reclaim the context
+    and kind-7 must advance.
+  * Unload_DroppedRootsWithoutAnyForcedAttempt_AlcIsCollectible -- the
+    purest contract: no attempt at all; same reclaim, same kind-7
+    proof.
+  * ForcedUnload_RetryAfterRootsDropped_CompletesWithZeroResidual -- a
+    host that does retry must observe Completed whether its retry or
+    the scout completion performed the teardown (tombstone idempotence)
+    and the scout residual must drain to zero.
+
+Refs https://github.com/unoplatform/Uno.DotnetRuntime.WebAssembly/issues/169.
+---
+ .../tests/ForcedNativeUnloadTests.cs          | 224 +++++++++++++++++-
+ .../Loader/AssemblyLoadContext.Mono.cs        |  11 +-
+ .../mono/metadata/assembly-load-context.c     | 172 ++++++++++----
+ src/mono/mono/metadata/loader-internals.h     |   7 +
+ 4 files changed, 370 insertions(+), 44 deletions(-)
+
+diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
+index 60708a1b5..ee90983aa 100644
+--- a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
++++ b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
+@@ -78,6 +78,10 @@ public class ForcedNativeUnloadTests
+         // manager's LoaderAllocator; mono_weak_hash_table_dead_lookup_count). Unconditional
+         // shared-runtime code, like kinds 2/3/5.
+         private const int WeakTableDeadLookupCount = 6;
++        // ALC teardowns completed by the GC-driven scout path (the finalizer of the last
++        // LoaderAllocator witness ran the quiescence-gated teardown itself; see
++        // LoaderAllocatorScout_Destroy). Behind the DISABLE_THREADS gate like kinds 0/1.
++        private const int ScoutCompletedTeardownCount = 7;
+ 
+         private static readonly MethodInfo s_forceNativeUnload = typeof(AssemblyLoadContext)
+             .GetMethod("ForceNativeUnload", BindingFlags.NonPublic | BindingFlags.Instance);
+@@ -269,6 +273,116 @@ public async Task ForcedUnload_OnlyCompletesOnceQuiescent()
+             }
+         }
+ 
++        /// <summary>
++        /// Regression for a downstream-observed per-cycle strand: a downstream WASM host doing
++        /// repeated collectible-ALC load/unload cycles called ForceNativeUnload once per cycle
++        /// while the context was still (transiently) rooted, got NotQuiescent, then dropped
++        /// every root WITHOUT retrying — and one disposed ALC accumulated per cycle until the
++        /// heap overflowed. Root cause: PrepareForAssemblyLoadContextRelease installs a STRONG
++        /// native gchandle to the managed ALC and only mono_alc_cleanup releases it; before the
++        /// GC-driven scout completion existed, only a Completed forced attempt ever ran that
++        /// cleanup, so a never-retried ALC — and everything the host's ALC subclass instance
++        /// references — stayed reachable forever. The attempt itself was already side-effect
++        /// free; the strand came from the Prepare-time handle having no GC-driven release.
++        /// Now the finalizer of the last LoaderAllocator witness runs the same all-or-nothing
++        /// quiescence-gated teardown, so plain GC reclaims the ALC once the roots are gone —
++        /// no retry required. Kind-7 of the scout stats proves the scout path really performed
++        /// the teardown (non-vacuity: under the opt-in the strong handle makes ALC death
++        /// impossible any other way, and the stat pins it explicitly).
++        /// </summary>
++        [Fact]
++        public async Task ForcedUnload_SingleNotQuiescentAttempt_ThenDroppedRoots_DoesNotStrandAlc()
++        {
++            if (BridgeMissing())
++            {
++                return;
++            }
++
++            int scoutCompletionsBefore = ProtocolActive ? ScoutStats(ScoutCompletedTeardownCount) : 0;
++
++            WeakReference weakRef = RootedSingleAttemptThenDrop();
++
++            await CollectAndAssertDeadAsync(weakRef,
++                "an ALC whose single forced attempt reported NotQuiescent must become collectible by plain GC " +
++                "once the host drops its roots — a never-retried attempt must not strand the context.");
++
++            if (ProtocolActive)
++            {
++                Assert.True(ScoutStats(ScoutCompletedTeardownCount) > scoutCompletionsBefore,
++                    "the reclaim must have been performed by the GC-driven scout completion " +
++                    $"(kind-7 before={scoutCompletionsBefore} after={ScoutStats(ScoutCompletedTeardownCount)}).");
++            }
++        }
++
++        /// <summary>
++        /// The purest statement of the fixed contract: no forced attempt at all. Unload() a
++        /// collectible context, drop every root, and plain GC must reclaim it — under the
++        /// opt-in via the scout completion (asserted through kind-7), and with the opt-in off
++        /// (or threads enabled) via the non-collectible Prepare path that releases the strong
++        /// handle immediately. Runs with the same assertion on every leg.
++        /// </summary>
++        [Fact]
++        public async Task Unload_DroppedRootsWithoutAnyForcedAttempt_AlcIsCollectible()
++        {
++            if (BridgeMissing())
++            {
++                return;
++            }
++
++            int scoutCompletionsBefore = ProtocolActive ? ScoutStats(ScoutCompletedTeardownCount) : 0;
++
++            WeakReference weakRef = LoadRootUnloadAndDrop();
++
++            await CollectAndAssertDeadAsync(weakRef,
++                "an unloaded collectible ALC must become collectible by plain GC once the host drops its roots, " +
++                "even if the host never calls ForceNativeUnload at all.");
++
++            if (ProtocolActive)
++            {
++                Assert.True(ScoutStats(ScoutCompletedTeardownCount) > scoutCompletionsBefore,
++                    "the reclaim must have been performed by the GC-driven scout completion " +
++                    $"(kind-7 before={scoutCompletionsBefore} after={ScoutStats(ScoutCompletedTeardownCount)}).");
++            }
++        }
++
++        /// <summary>
++        /// A host that DOES retry after dropping its roots must still observe Completed — either
++        /// because its retry performs the teardown, or because the scout completion beat it there
++        /// and the retry reports the already-completed state idempotently (the native struct is
++        /// kept as a tombstone precisely so this retry cannot dereference freed storage). The
++        /// scout residual must also fully drain.
++        /// </summary>
++        [Fact]
++        public async Task ForcedUnload_RetryAfterRootsDropped_CompletesWithZeroResidual()
++        {
++            if (BridgeMissing())
++            {
++                return;
++            }
++
++            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
++            var weakRef = new WeakReference(context);
++            FirstAttemptOnRootedContext(context);
++
++            if (ProtocolActive)
++            {
++                // Second attempt after the rooted state died: must reach Completed no matter
++                // whether this attempt or the scout completion performs the teardown.
++                Assert.Equal(Completed, await ForceUntilCompletedAsync(context, 10));
++                // Idempotence holds across the tombstone path too.
++                Assert.Equal(Completed, Force(context));
++                await DrainRetiredScoutsAsync();
++            }
++            else
++            {
++                Assert.Equal(Rejected, Force(context));
++            }
++
++            context = null;
++            await CollectAndAssertDeadAsync(weakRef,
++                "a retried forced unload must leave the context reclaimable with zero residual.");
++        }
++
+         [Fact]
+         public async Task ForcedUnload_RootedCrossContextGeneric_BlocksNativeFree()
+         {
+@@ -949,6 +1063,28 @@ private static async Task RunRejectedCycles(int cycles)
+         // loop (mono_main_thread_schedule_background_job). Finalizers therefore never run inside a
+         // synchronous test method — awaiting Task.Delay turns the event loop and runs the pump.
+         [MethodImpl(MethodImplOptions.NoInlining)]
++        // Waits for a WeakReference to die across collections, turning the JS event loop between
++        // attempts. The turns matter twice over: they re-dispatch the continuation on a nearly
++        // empty interpreter stack (see ForceUntilCompletedAsync), and they let the scheduled
++        // single-threaded finalizer pump run — the GC-driven scout completion (the teardown that
++        // releases the native strong handle to the managed ALC) happens inside a finalizer, and
++        // GC.WaitForPendingFinalizers alone is an immediate no-op on single-threaded wasm.
++        private static async Task CollectAndAssertDeadAsync(WeakReference weakRef, string reason)
++        {
++            for (int attempt = 0; attempt < 20; attempt++)
++            {
++                GcQuiesce();
++                if (!weakRef.IsAlive)
++                {
++                    return;
++                }
++
++                await Task.Delay(1);
++            }
++
++            Assert.False(weakRef.IsAlive, reason);
++        }
++
+         private static async Task DrainRetiredScoutsAsync()
+         {
+             for (int attempt = 0; attempt < 20; attempt++)
+@@ -966,6 +1102,91 @@ private static async Task DrainRetiredScoutsAsync()
+             Assert.Equal(0, ScoutStats(RetiredSetSize));
+         }
+ 
++        // One rooted-attempt-then-drop protocol, fully confined to this synchronous NoInlining
++        // frame so that when it returns, the context, the rooted instance and every loader
++        // temporary are structurally absent from the conservatively scanned live stack region —
++        // only the WeakReference escapes. The single forced attempt runs while the instance
++        // still roots the witness, reproducing the downstream host's teardown-time attempt.
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static WeakReference RootedSingleAttemptThenDrop()
++        {
++            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
++            var weakRef = new WeakReference(context);
++            object root = LoadUnloadReturningRootedInstance(context);
++
++            GcQuiesce();
++            int outcome = Force(context);
++            if (ProtocolActive)
++            {
++                // The live instance roots the LoaderAllocator witness, so the attempt must be
++                // refused — and (the point of the regression) must acquire nothing that outlives
++                // the refusal.
++                Assert.Equal(NotQuiescent, outcome);
++            }
++            else
++            {
++                // Opt-in off (natively non-collectible) or threads-enabled runtime (hard gate).
++                Assert.Equal(Rejected, outcome);
++            }
++
++            // The refused attempt must leave the rooted instance fully usable.
++            Assert.NotNull(root.ToString());
++
++            GC.KeepAlive(root);
++            GC.KeepAlive(context);
++            return weakRef;
++        }
++
++        // Same confinement discipline, without any forced attempt anywhere.
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static WeakReference LoadRootUnloadAndDrop()
++        {
++            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
++            var weakRef = new WeakReference(context);
++            object root = LoadUnloadReturningRootedInstance(context);
++
++            Assert.NotNull(root.ToString());
++
++            GC.KeepAlive(root);
++            GC.KeepAlive(context);
++            return weakRef;
++        }
++
++        // First (refused) attempt on a still-rooted context, with the root confined to this
++        // frame; the caller keeps only the context reference for its later retry.
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static void FirstAttemptOnRootedContext(AssemblyLoadContext context)
++        {
++            object root = LoadUnloadReturningRootedInstance(context);
++
++            GcQuiesce();
++            int outcome = Force(context);
++            if (ProtocolActive)
++            {
++                Assert.Equal(NotQuiescent, outcome);
++            }
++            else
++            {
++                Assert.Equal(Rejected, outcome);
++            }
++
++            GC.KeepAlive(root);
++        }
++
++        // Loads the collectible test assembly, instantiates a type from it (the managed root
++        // that keeps the LoaderAllocator witness alive), and initiates Unload — returning the
++        // instance as the caller-held root.
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static object LoadUnloadReturningRootedInstance(AssemblyLoadContext context)
++        {
++            Assembly asm = context.LoadFromAssemblyName(new AssemblyName(TestAssembly));
++            Type type = asm.GetType(TestClassName, throwOnError: true);
++            object instance = Activator.CreateInstance(type);
++            Assert.NotNull(instance);
++            context.Unload();
++            return instance;
++        }
++
+         [MethodImpl(MethodImplOptions.NoInlining)]
+         private static async Task<WeakReference> LoadExerciseUnloadAndForce()
+         {
+@@ -1554,7 +1775,8 @@ private static void Churn(int rounds)
+         // Holding asm/type/list in THIS frame across the force would keep the primary and
+         // shared-generic LoaderAllocator witnesses alive and pin the force at NotQuiescent. Only
+         // the ALC object itself lives here, which is safe: the runtime holds a strong handle to
+-        // it until a Completed force regardless (see LoadExerciseUnloadAndForce).
++        // it until the teardown completes — by a Completed force or the GC-driven scout
++        // completion — regardless (see LoadExerciseUnloadAndForce).
+         [MethodImpl(MethodImplOptions.NoInlining)]
+         private static async Task ReflectionHashInitUnderPressureCycle(int seed)
+         {
+diff --git a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
+index 88ce94a0c..019acbad9 100644
+--- a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
++++ b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
+@@ -78,6 +78,12 @@ private static void KeepLoaderAllocator()
+         // cycles rather than growing by three per reflection-using memory manager. Unlike kinds
+         // 0/1 these are available on every build, because the ownership fix they observe is
+         // unconditional (not part of the DISABLE_THREADS-gated forced teardown).
++        //
++        // Kind 7 counts ALC teardowns completed by the GC-driven scout path (the finalizer of
++        // the last LoaderAllocator witness ran the teardown because the whole set was already
++        // quiescent — see LoaderAllocatorScout_Destroy in assembly-load-context.c). Gated like
++        // kinds 0/1. Lifecycle tests use it to prove an ALC reclaimed after its host dropped
++        // every root really went through the scout path rather than a forced attempt.
+         internal static int GetScoutRetirementStats(int kind) => InternalGetScoutRetirementStats(kind);
+ 
+         [MethodImplAttribute(MethodImplOptions.InternalCall)]
+@@ -119,7 +125,10 @@ internal static int RunJiterpreterTableSelfTest()
+         // in the native assembly-load-context.c.
+         internal enum ForceNativeUnloadResult
+         {
+-            // The native teardown ran to completion and the ALC was freed.
++            // The native teardown ran to completion and the ALC was freed — either by this call,
++            // or earlier by the GC-driven scout completion (the finalizer of the last
++            // LoaderAllocator witness runs the same quiescence-gated teardown once the host's
++            // roots are gone; this call then reports the already-completed state idempotently).
+             Completed = 0,
+             // The managed LoaderAllocator is still rooted (its weak handle target is non-NULL), so
+             // freeing now would reclaim live memory. Nothing was freed; the caller should retry
+diff --git a/src/mono/mono/metadata/assembly-load-context.c b/src/mono/mono/metadata/assembly-load-context.c
+index d8eac6e34..3a550546d 100644
+--- a/src/mono/mono/metadata/assembly-load-context.c
++++ b/src/mono/mono/metadata/assembly-load-context.c
+@@ -80,6 +80,10 @@ alcs_unlock (void)
+ static GPtrArray *retired_scout_targets;
+ /* Monotonic count of scouts given a terminal (TRUE) Destroy outcome; diagnostics only. */
+ static gint32 retired_scout_terminal_count;
++/* Monotonic count of ALC teardowns completed by the GC-driven scout path (the finalizer of
++ * the last LoaderAllocator witness ran mono_alc_cleanup because the whole set was already
++ * quiescent); diagnostics only, exposed as kind 7 of InternalGetScoutRetirementStats. */
++static gint32 scout_completed_teardown_count;
+ 
+ static void
+ retired_scout_targets_add (MonoMemoryManager *memory_manager)
+@@ -320,16 +324,18 @@ mono_alc_cleanup (MonoAssemblyLoadContext *alc)
+ 	 * whole feature is hard-gated at compile time to the single-threaded browser build
+ 	 * (DISABLE_THREADS): on a threads-enabled runtime InternalForceNativeUnload rejects
+ 	 * up front and mono_alc_init never honours the collectible opt-in, so this function
+-	 * is unreachable there (its only caller is mono_alc_free from the gated icall) and
++	 * is unreachable there (its callers are mono_alc_free from the gated icall and the
++	 * DISABLE_THREADS-gated scout completion in LoaderAllocatorScout_Destroy) and
+ 	 * no preparation (mono_mem_manager_start_unload) has mutated the shared managers.
+ 	 * Within the gate the loader lock brackets the whole sequence (matching the scout
+ 	 * protocol) and is correctly ordered above the per-owner memory_managers_lock
+ 	 * (loader-internals.h locking hierarchy).
+ 	 *
+-	 * Quiescence: the caller (InternalForceNativeUnload) has already verified — before
+-	 * anything was freed — that EVERY manager deleted here (the primary above and each
+-	 * shared generic manager in this loop) has a dead LoaderAllocator liveness witness,
+-	 * so nothing reclaimed below can still be referenced from managed code.
++	 * Quiescence: the caller (InternalForceNativeUnload or the scout completion, both via
++	 * alc_is_managed_quiescent) has already verified — before anything was freed — that
++	 * EVERY manager deleted here (the primary above and each shared generic manager in
++	 * this loop) has a dead LoaderAllocator liveness witness, so nothing reclaimed below
++	 * can still be referenced from managed code.
+ 	 */
+ #ifdef DISABLE_THREADS
+ 	mono_loader_lock ();
+@@ -464,6 +470,56 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_PrepareForAssemblyLoadContex
+ 	mono_alc_memory_managers_unlock (alc);
+ }
+ 
++#ifdef DISABLE_THREADS
++/*
++ * Quiescence gate — ALL-OR-NOTHING over the exact set of managers a teardown would free.
++ * alc->unloading only means the managed Unload() was requested — it is NOT proof that the
++ * collectible LoaderAllocators have been collected. Stack frames, shared-generic type
++ * arguments, delegates and runtime handles can still root them (dotnet/runtime#40394,
++ * #34072). mono_mem_manager_start_unload already dropped the strong handles, so each
++ * LoaderAllocator is now held only by managed references; while a manager's weak-handle
++ * target is non-NULL, managed roots remain and freeing would reclaim live memory. This is
++ * exactly the criterion the LoaderAllocatorScout uses.
++ *
++ * Every shared/generic memory manager has its OWN LoaderAllocator witness: a live
++ * cross-context constructed generic (e.g. an instance whose vtable lives in a shared
++ * {default, this} manager) keeps that shared witness alive even after the primary witness
++ * has cleared. mono_alc_cleanup deletes the primary manager AND every shared generic
++ * manager on alc->generic_memory_managers, so each of those witnesses must be dead before
++ * anything is freed. If ANY witness is live, nothing may be freed. A NULL weak handle
++ * means no LoaderAllocator bookkeeping was ever materialised for that manager (no
++ * vtable/object of it ever existed), which is safe to free.
++ *
++ * Shared by the two teardown initiators: the host-triggered InternalForceNativeUnload
++ * below (which reports NotQuiescent so the host can retry) and the GC-driven scout
++ * completion in LoaderAllocatorScout_Destroy (which simply waits for a later finalization
++ * round).
++ */
++static gboolean
++alc_is_managed_quiescent (MonoAssemblyLoadContext *alc)
++{
++	MonoMemoryManager *primary_mm = alc->memory_manager;
++	if (primary_mm && primary_mm->loader_allocator_weak_handle &&
++			mono_gchandle_get_target_internal (primary_mm->loader_allocator_weak_handle) != NULL)
++		return FALSE;
++
++	gboolean witness_live = FALSE;
++	mono_alc_memory_managers_lock (alc);
++	for (guint i = 0; i < alc->generic_memory_managers->len; i++) {
++		MonoMemoryManager *mm = (MonoMemoryManager *)g_ptr_array_index (alc->generic_memory_managers, i);
++		if (mm == primary_mm)
++			continue;
++		if (mm->loader_allocator_weak_handle &&
++				mono_gchandle_get_target_internal (mm->loader_allocator_weak_handle) != NULL) {
++			witness_live = TRUE;
++			break;
++		}
++	}
++	mono_alc_memory_managers_unlock (alc);
++	return !witness_live;
++}
++#endif /* DISABLE_THREADS */
++
+ int
+ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (gpointer alc_pointer, MonoError *error)
+ {
+@@ -505,45 +561,19 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
+ 		return FORCE_UNLOAD_REJECTED;
+ 
+ 	/*
+-	 * Quiescence gate — ALL-OR-NOTHING over the exact set of managers the teardown will
+-	 * free. alc->unloading only means the managed Unload() was requested — it is NOT proof
+-	 * that the collectible LoaderAllocators have been collected. Stack frames,
+-	 * shared-generic type arguments, delegates and runtime handles can still root them
+-	 * (dotnet/runtime#40394, #34072). mono_mem_manager_start_unload already dropped the
+-	 * strong handles, so each LoaderAllocator is now held only by managed references; while
+-	 * a manager's weak-handle target is non-NULL, managed roots remain and freeing would
+-	 * reclaim live memory. This is exactly the criterion the (disabled)
+-	 * LoaderAllocatorScout uses.
+-	 *
+-	 * Every shared/generic memory manager has its OWN LoaderAllocator witness: a live
+-	 * cross-context constructed generic (e.g. an instance whose vtable lives in a shared
+-	 * {default, this} manager) keeps that shared witness alive even after the primary
+-	 * witness has cleared. mono_alc_cleanup deletes the primary manager AND every shared
+-	 * generic manager on alc->generic_memory_managers, so each of those witnesses must be
+-	 * dead before anything is freed. If ANY witness is live, free nothing and report
+-	 * NotQuiescent so the host retries after another GC rather than losing its single
+-	 * chance. A NULL weak handle means no LoaderAllocator bookkeeping was ever materialised
+-	 * for that manager (no vtable/object of it ever existed), which is safe to free.
++	 * Idempotent completion: the GC-driven scout path (LoaderAllocatorScout_Destroy below)
++	 * may have already torn this ALC down after the host's roots died — a downstream WASM
++	 * host doing repeated collectible-ALC load/unload cycles is not required to keep
++	 * retrying a NotQuiescent attempt for the reclamation to happen. Everything material
++	 * was freed by mono_alc_cleanup then; only this struct remains (see native_tombstoned
++	 * in loader-internals.h), so report Completed without dereferencing anything further.
++	 * The managed wrapper latches its terminal claim and zeroes its pointer on Completed,
++	 * exactly as if this call had performed the teardown itself.
+ 	 */
+-	MonoMemoryManager *primary_mm = alc->memory_manager;
+-	if (primary_mm && primary_mm->loader_allocator_weak_handle &&
+-			mono_gchandle_get_target_internal (primary_mm->loader_allocator_weak_handle) != NULL)
+-		return FORCE_UNLOAD_NOT_QUIESCENT;
++	if (alc->native_tombstoned)
++		return FORCE_UNLOAD_COMPLETED;
+ 
+-	gboolean witness_live = FALSE;
+-	mono_alc_memory_managers_lock (alc);
+-	for (guint i = 0; i < alc->generic_memory_managers->len; i++) {
+-		MonoMemoryManager *mm = (MonoMemoryManager *)g_ptr_array_index (alc->generic_memory_managers, i);
+-		if (mm == primary_mm)
+-			continue;
+-		if (mm->loader_allocator_weak_handle &&
+-				mono_gchandle_get_target_internal (mm->loader_allocator_weak_handle) != NULL) {
+-			witness_live = TRUE;
+-			break;
+-		}
+-	}
+-	mono_alc_memory_managers_unlock (alc);
+-	if (witness_live)
++	if (!alc_is_managed_quiescent (alc))
+ 		return FORCE_UNLOAD_NOT_QUIESCENT;
+ 
+ 	mono_alc_free (alc);
+@@ -593,6 +623,12 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+ 	 * mono_weak_hash_table_dead_lookup_count). Unconditional like kinds 2/3/5. A lifecycle test
+ 	 * uses it to prove the global assembly enumeration really took the terminal dead-cache path
+ 	 * for a condemned assembly (skipping it) instead of passing vacuously.
++	 *
++	 * Kind 7 — monotonic count of ALC teardowns completed by the GC-driven scout path (see
++	 * scout_completed_teardown_count and LoaderAllocatorScout_Destroy). Behind the
++	 * DISABLE_THREADS gate like kinds 0/1. Lifecycle tests use it to prove an ALC whose host
++	 * dropped every root without retrying a NotQuiescent forced attempt was really reclaimed
++	 * by the scout finalizer rather than by a forced attempt.
+ 	 */
+ 	if (kind == 2 || kind == 3)
+ 		return mono_weak_hash_table_key_value_handle_stats (kind - 2);
+@@ -611,6 +647,8 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+ 		return retired_scout_terminal_count;
+ 	case 4:
+ 		return mono_mem_manager_alc_unload_test_gc_hook_count ();
++	case 7:
++		return scout_completed_teardown_count;
+ 	default:
+ 		return -1;
+ 	}
+@@ -1109,6 +1147,56 @@ ves_icall_System_Reflection_LoaderAllocatorScout_Destroy (gpointer native)
+ 		retired_scout_terminal_count++;
+ 		return TRUE;
+ 	}
++
++	/*
++	 * GC-driven completion for the opt-in forced-unload flow. `native` was not in the
++	 * retired registry, so it is a LIVE memory manager (only the forced teardown frees
++	 * managers, and it registers every one it frees) and may be dereferenced. This scout
++	 * finalizing means ITS LoaderAllocator witness is dead; if the manager is owned by a
++	 * collectible, unloading ALC whose WHOLE witness set is dead, complete the teardown
++	 * here — a downstream WASM host doing repeated collectible-ALC load/unload cycles
++	 * whose single ForceNativeUnload attempt reported NotQuiescent (and which then dropped
++	 * every root without retrying) would otherwise strand the managed ALC forever: the
++	 * strong alc->gchandle installed by PrepareForAssemblyLoadContextRelease is released
++	 * only by mono_alc_cleanup, and before this path existed only a Completed forced
++	 * attempt ever ran it. Now the last witness's finalizer runs the SAME all-or-nothing
++	 * quiescence gate and the SAME cleanup; the struct itself is kept as a tiny tombstone
++	 * (native_tombstoned) so a host that still holds the managed ALC and retries later
++	 * gets an idempotent Completed instead of a use-after-free (see
++	 * InternalForceNativeUnload above).
++	 *
++	 * Single-threaded by construction (finalizers and icalls share the one thread), so
++	 * this cannot interleave with a managed forced attempt; collectible is only ever TRUE
++	 * under the MONO_WASM_ENABLE_ALC_UNLOAD opt-in (mono_alc_init), so default consumers
++	 * never take this branch. The owner scan runs BEFORE mono_alc_cleanup because the
++	 * cleanup frees this manager (mm->alcs lives in its mempool).
++	 */
++	MonoMemoryManager *mm = (MonoMemoryManager *)native;
++	MonoAssemblyLoadContext *condemned = NULL;
++	for (int i = 0; i < mm->n_alcs; ++i) {
++		MonoAssemblyLoadContext *owner = mm->alcs [i];
++		if (!owner || !owner->collectible || !owner->unloading || owner->native_tombstoned)
++			continue;
++		if (!alc_is_managed_quiescent (owner))
++			continue;
++		condemned = owner;
++		break;
++	}
++	if (condemned) {
++		mono_alc_cleanup (condemned);
++		condemned->native_tombstoned = TRUE;
++		scout_completed_teardown_count++;
++		/*
++		 * The cleanup freed this scout's own manager and registered it (with every other
++		 * materialised manager of the ALC) in the retired registry, so consume the entry
++		 * now for the terminal outcome instead of waiting for a pointless extra
++		 * finalization round.
++		 */
++		if (retired_scout_targets_consume (native)) {
++			retired_scout_terminal_count++;
++			return TRUE;
++		}
++	}
+ #endif
+ 
+ 	/* Not enabled yet */
+diff --git a/src/mono/mono/metadata/loader-internals.h b/src/mono/mono/metadata/loader-internals.h
+index 4275a39d2..b8f5e1f14 100644
+--- a/src/mono/mono/metadata/loader-internals.h
++++ b/src/mono/mono/metadata/loader-internals.h
+@@ -107,6 +107,13 @@ struct _MonoAssemblyLoadContext {
+ 	gboolean collectible;
+ 	// Set to TRUE when the unloading process has begun
+ 	gboolean unloading;
++	// Set to TRUE when the GC-driven scout completion (LoaderAllocatorScout_Destroy) has
++	// already run mono_alc_cleanup for this ALC. Everything material is freed; only this
++	// struct remains, kept as a tiny tombstone so a host that still holds the managed ALC
++	// and calls ForceNativeUnload afterwards gets an idempotent Completed instead of
++	// dereferencing freed storage. Only meaningful for collectible ALCs under the
++	// MONO_WASM_ENABLE_ALC_UNLOAD opt-in on the single-threaded browser build.
++	gboolean native_tombstoned;
+ 	// Used in native-library.c for the hash table below; do not access anywhere else
+ 	MonoCoopMutex pinvoke_lock;
+ 	// Maps malloc-ed char* pinvoke scope -> MonoDl*
+-- 
+2.53.0.vfs.0.0
+

--- a/scripts/check-loader-results.sh
+++ b/scripts/check-loader-results.sh
@@ -68,6 +68,9 @@ JiterpreterTableStat_SurfaceMatchesOptIn
 ForcedUnload_ReclaimsJiterpreterTraceTableSlots
 ForcedUnload_WithoutAnyCompiledTrace_ReleasesNoSlots
 JiterpreterTableAllocator_ExhaustionSelfTest
+ForcedUnload_SingleNotQuiescentAttempt_ThenDroppedRoots_DoesNotStrandAlc
+Unload_DroppedRootsWithoutAnyForcedAttempt_AlcIsCollectible
+ForcedUnload_RetryAfterRootsDropped_CompletesWithZeroResidual
 "
 if [ "$mode" = "mt" ]; then
   # The threads-enabled rejection test is [ConditionalFact(IsThreadingSupported)]: it self-skips

--- a/scripts/check-loader-results.sh
+++ b/scripts/check-loader-results.sh
@@ -72,6 +72,7 @@ ForcedUnload_SingleNotQuiescentAttempt_ThenDroppedRoots_DoesNotStrandAlc
 Unload_DroppedRootsWithoutAnyForcedAttempt_AlcIsCollectible
 ForcedUnload_RetryAfterRootsDropped_CompletesWithZeroResidual
 RepeatedUnloadWithoutRetry_NativeStructPopulationReturnsToBaseline
+ScoutCompletion_LatchesBaseFields_WhenSubclassHidesThem
 "
 if [ "$mode" = "mt" ]; then
   # The threads-enabled rejection test is [ConditionalFact(IsThreadingSupported)]: it self-skips

--- a/scripts/check-loader-results.sh
+++ b/scripts/check-loader-results.sh
@@ -71,6 +71,7 @@ JiterpreterTableAllocator_ExhaustionSelfTest
 ForcedUnload_SingleNotQuiescentAttempt_ThenDroppedRoots_DoesNotStrandAlc
 Unload_DroppedRootsWithoutAnyForcedAttempt_AlcIsCollectible
 ForcedUnload_RetryAfterRootsDropped_CompletesWithZeroResidual
+RepeatedUnloadWithoutRetry_NativeStructPopulationReturnsToBaseline
 "
 if [ "$mode" = "mt" ]; then
   # The threads-enabled rejection test is [ConditionalFact(IsThreadingSupported)]: it self-skips


### PR DESCRIPTION
## Problem

A downstream WASM host doing repeated collectible-ALC load/unload cycles observed **one disposed AssemblyLoadContext stranded per cycle** with `MONO_WASM_ENABLE_ALC_UNLOAD` active (monotonic 2→13 across its CI run, heap growth to native OOM), while the identical host wiring collected normally with the flag off. The host calls `ForceNativeUnload` once at teardown while the context is still transiently rooted, gets `NotQuiescent`, then drops every root and never retries.

## Root cause (audited, not the initial hypothesis)

The initial hypothesis — a per-attempt acquisition not released on the `NotQuiescent` early-out — is **disproven by the code**: the icall takes no handle, registration, or allocation before its quiescence walk (both early-outs return before any mutation), and the managed claim CAS is released on `NotQuiescent`/`Rejected`.

The strand predates the attempt: `PrepareForAssemblyLoadContextRelease` (managed `Unload()`) swaps the native handle to the managed ALC from weak to **strong** for the unloading window, and the only release of that handle is `mono_alc_cleanup` — which, before this PR, only a **Completed** forced attempt ever ran. Flag-off, the ALC is natively non-collectible and Prepare frees the strong handle immediately (hence the clean flag-off legs). Flag-on, a host that never re-attempts leaves the managed context — and everything its ALC subclass instance references (stream resolvers, assembly bytes) — strongly rooted forever. One stranded context per cycle, exactly as observed.

## Fix (patch 0013)

GC-driven completion, mirroring the CoreCLR `LoaderAllocatorScout` design:

- `LoaderAllocatorScout_Destroy` (previously terminal-registry-consult-only here) now **completes the teardown itself** when the finalizing scout's manager belongs to a collectible, unloading, not-yet-torn-down ALC whose *whole* witness set is dead — the same all-or-nothing quiescence gate as the forced attempt, factored into `alc_is_managed_quiescent`. The last witness's finalizer is the first moment this can succeed, so plain GC now reclaims the ALC with no host retry; a partially-live set re-registers for finalization (the pre-existing managed retry loop).
- **Tombstone, not free**: the scout path keeps the ~100-byte `MonoAssemblyLoadContext` struct (`native_tombstoned`) because a host may still hold the managed context and retry `ForceNativeUnload` with the raw native pointer — the retry now gets an idempotent `Completed` instead of a use-after-free. A Completed forced attempt still frees the struct as before.
- Ordering safety inherits the retired-scout registry (consumed at the top of `Destroy`, freed managers never dereferenced); everything stays hard-gated (DISABLE_THREADS + opt-in; `collectible` is only ever TRUE under the opt-in).
- Diagnostics: scout-stats **kind 7** counts scout-driven completions so the tests cannot pass vacuously.

## Red/fix/green

Three new lifecycle tests, required by `scripts/check-loader-results.sh`:

- `ForcedUnload_SingleNotQuiescentAttempt_ThenDroppedRoots_DoesNotStrandAlc` — the reported shape; **red on the previous runtime** exactly on the flag-on leg (like the field failure), green flag-off/threads. Kind-7 must advance by exactly one.
- `Unload_DroppedRootsWithoutAnyForcedAttempt_AlcIsCollectible` — the purest contract (no attempt at all); **red on the previous runtime** on the flag-on leg.
- `ForcedUnload_RetryAfterRootsDropped_CompletesWithZeroResidual` — *not* a strand red (it also passes pre-fix): a deterministic coverage guard for the tombstone-retry branch — it pumps GC until the scout completion provably performed the teardown (kind-7 advance) before retrying, so the retry always lands on `native_tombstoned` (the UAF guard), then asserts the further call is answered by the managed terminal-claim latch and that the scout registry and pending-unloads gauge drain to zero.

## Validation

Fresh checkout at pin `742e2f07` → `git apply --check` + apply of all **13** patches in sorted order passes plain **and** with `--whitespace=fix`; both applied trees are byte-identical to the resolution tree (git tree `ea7cd7111cf9`). Patch wording grepped product-neutral.

Fixes #169 (remaining downstream per-cycle strand).

## Review-panel round (cb0c89a)

- Tombstone-retry now **frees the struct** (the retry is provably the last carrier of the raw pointer; never-retrying hosts keep the documented ~100 B/cycle bounded residual).
- New scout-stats **kind 8** gauge (pending unloads) makes a never-dying witness observable; tests assert it drains to 0.
- Alternatives record and the zero-witness invariant (eager primary LoaderAllocator per opted-in ALC) documented in the patch header, each verified against the source.
- `g_assert` on the registry consume in the scout completion; exact kind-7 (+1) assertions.
- Bridge-missing vacuity: already covered suite-wide — all three CI legs set `MONO_WASM_ALC_UNLOAD_REQUIRE_BRIDGE=1`, which makes `BridgeMissing()` fail (not skip) when the bridge should exist.
- Global-list membership: already correct — `mono_alc_cleanup` (whose only caller is still `mono_alc_free`, now reached from two gated initiators: the forced icall and the scout completion) unlinks from the global ALC list.

## Post-approval polish round (9bb0b17, human review)

Current design summary superseding earlier round notes: the scout completion **latches the surviving wrapper terminal from native** (pointer zeroed, then claim 2 — order load-bearing, documented at both field declarations) and frees the struct outright via `mono_alc_free`; latch fields resolve from the declaring `AssemblyLoadContext` class (subclass shadow-proof, type/parent-asserted); the **spontaneous terminal window** (loads throwing `ObjectDisposedException` at a GC-chosen moment under the opt-in) is documented as the host-visible contract on `ForceNativeUnload`; diagnostics kinds 7–10 (completions, pending-unloads gauge, native-struct ledger, deferral counter) make every scout outcome observable, with five required lifecycle tests plus a deterministic deferral probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


