### PR TITLE
feat(patches): referrer lookup for condemned collectible ALC witnesses

### DIFF
--- a/.github/workflows/runtime-ci.yml
+++ b/.github/workflows/runtime-ci.yml
@@ -579,6 +579,12 @@ jobs:
         # pinned-holder construction window, and the pressure test asserts the fire counter
         # (kind 4) advanced at least once per init — reverting the holder pins fails this leg
         # deterministically instead of depending on stochastic churn.
+        # MONO_WASM_ALC_UNLOAD_REFERRER_SLOT_BUDGET=50000 LOWERS the referrer scan's reference-slot
+        # budget (the runtime clamps it to the production value, so an override can only shrink the
+        # walk). Without it saturation is unreachable from a test — a test heap cannot produce two
+        # million reference slots — so deleting the per-slot charge outright would leave every
+        # assertion passing. ForcedUnload_ReferrerScan_LargeReferenceArrayStillReports sizes its
+        # array from this value and asserts the cutoff is crossed exactly at it.
         # MONO_WASM_ALC_UNLOAD_REFERRER_SCAN=1 arms the pause-time condemned-referrer scan. This
         # is the ONLY leg that arms it, and it exists because nothing did: that code shipped a
         # wrong precondition assertion twice while every build stayed green, since its only other
@@ -597,7 +603,7 @@ jobs:
         ./dotnet.sh build /t:Test src/libraries/System.Runtime.Loader/tests \
           /p:TargetOS=browser /p:TargetArchitecture=wasm /p:Configuration=Release \
           /p:InstallV8ForTests=true \
-          "/p:WasmXHarnessMonoArgs=--setenv=MONO_WASM_ENABLE_ALC_UNLOAD=1 --setenv=MONO_WASM_ALC_UNLOAD_REQUIRE_BRIDGE=1 --setenv=MONO_WASM_ALC_UNLOAD_TEST_GC_HOOK=1 --setenv=MONO_WASM_ALC_UNLOAD_REFERRER_SCAN=1"
+          "/p:WasmXHarnessMonoArgs=--setenv=MONO_WASM_ENABLE_ALC_UNLOAD=1 --setenv=MONO_WASM_ALC_UNLOAD_REQUIRE_BRIDGE=1 --setenv=MONO_WASM_ALC_UNLOAD_TEST_GC_HOOK=1 --setenv=MONO_WASM_ALC_UNLOAD_REFERRER_SCAN=1 --setenv=MONO_WASM_ALC_UNLOAD_REFERRER_SLOT_BUDGET=50000"
         # Exactly-one selection (stale-result guard): every testResults.xml under the suite's
         # artifacts dir was deleted BEFORE the invocation above, so require EXACTLY ONE here.
         # A newest-file selector plus a `-z` emptiness check was not enough: `/t:Test` can exit
@@ -616,7 +622,44 @@ jobs:
         cp "$results" "$GITHUB_WORKSPACE/loader-results-flag-on.xml"
         # Invoke via `bash` (not by path) so the step is robust regardless of the script's
         # file mode — a newly-added .sh may land without the executable bit on checkout.
-        bash "$GITHUB_WORKSPACE/scripts/check-loader-results.sh" "$results" "flag ON"
+        bash "$GITHUB_WORKSPACE/scripts/check-loader-results.sh" "$results" "flag ON" st referrer
+
+    - name: Run System.Runtime.Loader tests (flag ON, referrer scan OFF — second opt-in gates)
+      run: |
+        set -e
+        cd runtime
+        # THE DOUBLE OPT-IN LEG. MONO_WASM_ENABLE_ALC_UNLOAD=1 with
+        # MONO_WASM_ALC_UNLOAD_REFERRER_SCAN deliberately ABSENT: the collectible teardown feature
+        # is fully active, so refusals are real and the referrer scan's request path is reachable —
+        # and it must still do nothing, because the scan needs its own opt-in.
+        #
+        # Without this leg that gating was asserted nowhere. The flag-OFF leg cannot cover it (with
+        # the feature off nothing is collectible, so no refusal happens at all) and the MT leg
+        # cannot (the surface is compiled out). So deleting the second opt-in check — making a
+        # flagged session silently pay for a heap walk in every collection pause — would have
+        # stayed green on every leg.
+        #
+        # The referrer tests assert kind 11 does NOT advance here after a real refusal, and the
+        # sentinel requires them present and passed, so they cannot regress to self-skipping and
+        # take the coverage with them.
+        suite=artifacts/bin/System.Runtime.Loader.Tests
+        if [ -d "$suite" ]; then
+          find "$suite" -name testResults.xml -delete
+        fi
+        ./dotnet.sh build /t:Test src/libraries/System.Runtime.Loader/tests \
+          /p:TargetOS=browser /p:TargetArchitecture=wasm /p:Configuration=Release \
+          /p:InstallV8ForTests=true \
+          "/p:WasmXHarnessMonoArgs=--setenv=MONO_WASM_ENABLE_ALC_UNLOAD=1 --setenv=MONO_WASM_ALC_UNLOAD_REQUIRE_BRIDGE=1 --setenv=MONO_WASM_ALC_UNLOAD_TEST_GC_HOOK=1"
+        matches=$(find "$suite" -name testResults.xml)
+        count=$(printf '%s\n' "$matches" | grep -c . || true)
+        if [ "$count" -ne 1 ]; then
+          echo "::error::Expected exactly one testResults.xml under $suite produced by this invocation, found $count." >&2
+          printf '%s\n' "$matches" >&2
+          exit 1
+        fi
+        results=$matches
+        cp "$results" "$GITHUB_WORKSPACE/loader-results-flag-on-scan-off.xml"
+        bash "$GITHUB_WORKSPACE/scripts/check-loader-results.sh" "$results" "flag ON scan OFF" st referrer
 
     - uses: actions/upload-artifact@v4
       if: ${{ always() }}
@@ -624,6 +667,7 @@ jobs:
         name: loader-wasm-test-logs
         path: |
           loader-results-flag-off.xml
+          loader-results-flag-on-scan-off.xml
           loader-results-flag-on.xml
           runtime/artifacts/log/**
 

--- a/.github/workflows/runtime-ci.yml
+++ b/.github/workflows/runtime-ci.yml
@@ -579,6 +579,14 @@ jobs:
         # pinned-holder construction window, and the pressure test asserts the fire counter
         # (kind 4) advanced at least once per init — reverting the holder pins fails this leg
         # deterministically instead of depending on stochastic churn.
+        # MONO_WASM_ALC_UNLOAD_REFERRER_SCAN=1 arms the pause-time condemned-referrer scan. This
+        # is the ONLY leg that arms it, and it exists because nothing did: that code shipped a
+        # wrong precondition assertion twice while every build stayed green, since its only other
+        # output is trace text no test can read. Armed here,
+        # ForcedUnload_ReferrerScan_RefusalIsServedAtNextCollection asserts stat kind 11 advances
+        # after a refusal plus a collection — so an abort or an early return inside the pause hook
+        # fails this leg instead of passing silently. The MT leg deliberately stays unarmed: the
+        # surface is compiled out there and that job's charter is proving rejection.
         # Stale-result guard (see the exactly-one selection below): clear any testResults.xml a
         # earlier leg or rerun left behind, so the file this step validates can only have
         # been produced by the invocation below.
@@ -589,7 +597,7 @@ jobs:
         ./dotnet.sh build /t:Test src/libraries/System.Runtime.Loader/tests \
           /p:TargetOS=browser /p:TargetArchitecture=wasm /p:Configuration=Release \
           /p:InstallV8ForTests=true \
-          "/p:WasmXHarnessMonoArgs=--setenv=MONO_WASM_ENABLE_ALC_UNLOAD=1 --setenv=MONO_WASM_ALC_UNLOAD_REQUIRE_BRIDGE=1 --setenv=MONO_WASM_ALC_UNLOAD_TEST_GC_HOOK=1"
+          "/p:WasmXHarnessMonoArgs=--setenv=MONO_WASM_ENABLE_ALC_UNLOAD=1 --setenv=MONO_WASM_ALC_UNLOAD_REQUIRE_BRIDGE=1 --setenv=MONO_WASM_ALC_UNLOAD_TEST_GC_HOOK=1 --setenv=MONO_WASM_ALC_UNLOAD_REFERRER_SCAN=1"
         # Exactly-one selection (stale-result guard): every testResults.xml under the suite's
         # artifacts dir was deleted BEFORE the invocation above, so require EXACTLY ONE here.
         # A newest-file selector plus a `-z` emptiness check was not enough: `/t:Test` can exit

--- a/patches/0015-report-referrers-of-condemned-collectible-alc-witnesses.patch
+++ b/patches/0015-report-referrers-of-condemned-collectible-alc-witnesses.patch
@@ -48,16 +48,39 @@ read-only gauge a caller chooses to poll -- this adds work to a collection
 pause, so a flagged session that has not asked for referrers pays one load
 and a branch. The regression asserts that gating in both directions.
 
-WHAT IT BOUNDS, AND WHAT IT DOES NOT. object_budget caps the per-object
-reference scan and NOT the object enumeration: sgen's iterators run to
-completion and their callbacks cannot stop them, and the walk passes
-ITERATE_OBJECTS_SWEEP_ALL exactly as mono_gc_walk_heap does, which forces a
-lazily-swept major heap to finish sweeping. So a scan costs a full
-enumeration plus at most object_budget reference scans, and the budget is a
-bound on the second half only. Because the iterators always finish,
-objects_visited is a TRUE total rather than an estimate, and
-objects_scanned/objects_visited plus `saturated` say exactly how much of the
-heap the answer covers.
+TWO PASSES, because one is not exhaustive. The heap walk is descriptor-driven,
+and sgen zeroes the GC descriptor bitmap for System.Runtime.Ephemeron
+(object.c, "An Ephemeron cannot be marked by sgen"), so a
+ConditionalWeakTable or DependentHandle value edge is invisible to it -- while
+being a genuine root, since sgen_client_mark_ephemerons marks the value
+whenever the key is alive. On mono that is not a corner case: DependentHandle
+IS an Ephemeron[] ("Instead of dependent handles, mono uses arrays of
+Ephemeron objects"), so every CWT goes through it. A witness held only that
+way would have produced an unsaturated EMPTY report -- a false negative of
+exactly the kind this surface exists to rule out. A second pass walks
+ephemeron_list at the same suspended point, mirroring the collector's own
+liveness and tombstone tests so it reports the edges the collector actually
+traverses, and records the KEY as the referrer with the row marked dependent.
+
+TWO BUDGETS, and neither bounds the pause. object_budget caps how many objects
+are ENTERED. reference_slot_budget caps the SET LOOKUPS, across every object
+entered and the ephemeron pass, and it exists because the object budget bounded
+nothing expensive: the per-object scan invokes its callback once per reference
+-- once per ELEMENT of a vector or complex array -- so one large object[] cost
+a single object unit while performing millions of lookups on the one suspended
+thread. That is the same defect shape as bounding a handle walk on classified
+hits instead of raw slots.
+
+What the budgets do NOT cover, stated because "bounded" was previously claimed
+too broadly: the slot enumeration WITHIN an object already entered cannot be
+interrupted (sgen-scan-object.h expands to a loop this code cannot break out
+of), the heap enumeration is unbounded, and ITERATE_OBJECTS_SWEEP_ALL forces a
+lazily-swept major heap to finish sweeping, exactly as mono_gc_walk_heap does.
+A scan costs that enumeration plus the intra-object slot loads of everything
+entered plus at most reference_slot_budget lookups. Because the iterators
+always finish, objects_visited is a TRUE total, and
+objects_scanned/objects_visited, reference_slots_visited and `saturated`
+together say how much of the heap an answer covers.
 
 A referrer row is direct evidence. An EMPTY report is much weaker and means
 anything only when the scan did not saturate -- and the report is written to
@@ -93,22 +116,33 @@ empty inline there. The reasoning is recorded at the call site rather than
 left implicit, because it stops being true the moment someone builds this
 with threads enabled.
 
-OBSERVABILITY, so this can actually be tested. The scan's only other output
-is trace text, so nothing could distinguish an armed scan from one that never
-ran -- which is precisely how two wrong assertions survived a fully green
-build. Stat kind 11 now counts scans that completed a heap walk AND emitted
-their report, deliberately excluding the early return taken when the
-condemned set has already emptied, so a bump cannot be earned by a scan that
-never looked at the heap. It is a lone monotonic gauge like kinds 7 and 10,
-not a field of a tuple, so it reintroduces none of the cross-read
-consistency problems that shaped the snapshot surface.
+OBSERVABILITY, so this can actually be tested. The scan's only other output is
+trace text, so nothing could distinguish an armed scan from one that never ran
+-- which is precisely how two wrong assertions survived a fully green build.
+Three stat kinds now exist: kind 11 counts scans that completed a walk AND
+emitted their report (excluding the early return taken when the condemned set
+has already emptied, so it cannot be earned by a scan that never looked at the
+heap), and kinds 12 and 13 report the last reported scan's total and DEPENDENT
+edge counts. Kind 13 is what makes the ephemeron blind spot testable at all.
+They are independent gauges, not a tuple: read kind 11 around 12/13 to know
+which scan they describe.
 
-ForcedUnload_ReferrerScan_RefusalIsServedAtNextCollection drives a refusal
-with the same rooted pointer-free probe the existing witness regression uses,
-forces a collection, and asserts kind 11 advanced when the second opt-in is
-set and did NOT advance when it is absent. It asserts the refusal itself
-rather than tolerating a Completed, since a Completed would make the rest
-vacuous.
+Three regressions, all on the single-threaded flag-ON leg, which now sets
+MONO_WASM_ALC_UNLOAD_REFERRER_SCAN=1 -- the only leg that arms this code:
+
+  * ForcedUnload_ReferrerScan_RefusalIsServedAtNextCollection -- a refusal plus
+    a collection advances kind 11 with the second opt-in set, and does NOT
+    without it, so the double opt-in is asserted in both directions.
+  * ForcedUnload_ReferrerScan_ReportsConditionalWeakTableDependentEdge -- a
+    live CWT key whose value is the condemned wrapper must produce a dependent
+    edge. Descriptor scanning structurally cannot see it, so this fails if the
+    ephemeron pass regresses.
+  * ForcedUnload_ReferrerScan_LargeReferenceArrayStillReports -- a 200k-element
+    reference array holding the wrapper must still report, which is where an
+    unbounded per-slot cost would surface.
+
+Each asserts the refusal itself rather than tolerating a Completed, since a
+Completed would make the rest vacuous.
 
 Temporary diagnostic scaffolding on the same terms and the same tracking
 issue (#176) as the snapshot it complements: it retires when the residual
@@ -116,16 +150,16 @@ root is found and fixed, or when the stop-rule fires.
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
 ---
- .../tests/ForcedNativeUnloadTests.cs          |  70 ++++++
- .../mono/metadata/assembly-load-context.c     | 233 +++++++++++++++++-
- src/mono/mono/metadata/gc-internals.h         |  91 +++++++
- src/mono/mono/metadata/loader-internals.h     |  15 ++
- src/mono/mono/metadata/sgen-mono.c            | 187 ++++++++++++++
- src/mono/mono/metadata/sgen-stw.c             |  16 ++
- 6 files changed, 610 insertions(+), 2 deletions(-)
+ .../tests/ForcedNativeUnloadTests.cs          | 181 +++++++++++
+ .../mono/metadata/assembly-load-context.c     | 291 +++++++++++++++++-
+ src/mono/mono/metadata/gc-internals.h         | 138 +++++++++
+ src/mono/mono/metadata/loader-internals.h     |  15 +
+ src/mono/mono/metadata/sgen-mono.c            | 288 +++++++++++++++++
+ src/mono/mono/metadata/sgen-stw.c             |  16 +
+ 6 files changed, 927 insertions(+), 2 deletions(-)
 
 diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
-index 2b2f170..b9e708f 100644
+index 2b2f170..3ef83c9 100644
 --- a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 +++ b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 @@ -178,6 +178,14 @@ private static bool FlagEnabled
@@ -143,7 +177,7 @@ index 2b2f170..b9e708f 100644
          // Returns true (and the caller should no-op) only on a genuinely unpatched runtime. When CI
          // asserts the bridge must exist, a missing member fails loudly instead of self-skipping and
          // masking the regression.
-@@ -1585,6 +1593,68 @@ public async Task ForcedUnload_RootedPointerFreeObjects_BlockNativeFree()
+@@ -1585,6 +1593,179 @@ public async Task ForcedUnload_RootedPointerFreeObjects_BlockNativeFree()
              await RunConservativelyPinnedLosWitnessProtocol();
          }
  
@@ -209,14 +243,125 @@ index 2b2f170..b9e708f 100644
 +            GC.KeepAlive(rooted);
 +        }
 +
++        /// <summary>
++        /// A witness reachable ONLY as the dependent value of a live ConditionalWeakTable key must
++        /// still be reported, with the edge marked dependent.
++        ///
++        /// This is the case descriptor scanning structurally cannot see: sgen zeroes the GC bitmap
++        /// for System.Runtime.Ephemeron ("An Ephemeron cannot be marked by sgen" in object.c), so
++        /// an ephemeron array reports no references at all, while sgen_client_mark_ephemerons
++        /// still marks the value whenever the key is alive. Without the dedicated ephemeron pass
++        /// such a witness produces an UNSATURATED EMPTY report — which would be a false negative
++        /// of exactly the kind this diagnostic exists to rule out.
++        ///
++        /// The witness used is the condemned context's own managed wrapper, which is a member of
++        /// the condemned identity set, so no unloadable-assembly type has to survive to make the
++        /// point.
++        /// </summary>
++        [Fact]
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        public void ForcedUnload_ReferrerScan_ReportsConditionalWeakTableDependentEdge()
++        {
++            if (BridgeMissing())
++            {
++                return;
++            }
++
++            if (!ProtocolActive || !ReferrerScanRequested)
++            {
++                return;
++            }
++
++            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
++            object[] rooted = LoadUnloadReturningRootedPointerFreeProbe(context, losArray: true, new WeakReference[1]);
++
++            // The dependent edge: a live key whose VALUE is the condemned wrapper. The key must be
++            // a distinct live object with no other path to the witness, so the only edge into the
++            // witness from this table is the ephemeron one.
++            var key = new object();
++            var table = new ConditionalWeakTable<object, object>();
++            table.Add(key, context);
++
++            int scansBefore = ScoutStats(11);
++            Assert.Equal(NotQuiescent, Force(context));
++            GcQuiesce();
++
++            // Kind 11 must have advanced, or kinds 12/13 describe some earlier scan.
++            Assert.True(ScoutStats(11) > scansBefore,
++                $"no referrer scan was reported (kind 11 was {scansBefore}, now {ScoutStats(11)}), so the dependent-edge assertions below would describe a different scan.");
++
++            Assert.True(ScoutStats(13) > 0,
++                $"the ConditionalWeakTable dependent edge onto the condemned wrapper was not reported: kind 13 (dependent edges) is {ScoutStats(13)} with kind 12 (total edges) at {ScoutStats(12)}. Descriptor scanning cannot see this edge, so a zero here means the ephemeron pass did not run or did not match.");
++
++            // Everything must outlive the assertions: dropping the table or the key would kill the
++            // dependent edge, and dropping the probe would end the refusal.
++            GC.KeepAlive(rooted);
++            GC.KeepAlive(key);
++            GC.KeepAlive(table);
++        }
++
++        /// <summary>
++        /// One large reference array must not be able to spend an unbounded number of set lookups.
++        ///
++        /// The object budget alone bounded only how many objects are ENTERED, so a single
++        /// object[] with millions of elements cost one object unit while performing a lookup per
++        /// element on the suspended browser thread. The reference-slot budget bounds the lookups
++        /// instead; this asserts the scan still completes and reports, with the array live and
++        /// referenced, rather than asserting a particular saturation flag — the budget is sized
++        /// well above what a test heap can reach, so demanding saturation here would be asserting
++        /// the budget's value rather than its existence.
++        /// </summary>
++        [Fact]
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        public void ForcedUnload_ReferrerScan_LargeReferenceArrayStillReports()
++        {
++            if (BridgeMissing())
++            {
++                return;
++            }
++
++            if (!ProtocolActive || !ReferrerScanRequested)
++            {
++                return;
++            }
++
++            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
++            object[] rooted = LoadUnloadReturningRootedPointerFreeProbe(context, losArray: true, new WeakReference[1]);
++
++            // A large reference array whose elements are non-null, so every element costs a slot
++            // charge. One element points at the condemned wrapper, so the array is also a genuine
++            // referrer and the walk cannot skip it as uninteresting.
++            object[] wide = new object[200_000];
++            object filler = new object();
++            for (int i = 0; i < wide.Length; i++)
++            {
++                wide[i] = filler;
++            }
++            wide[wide.Length - 1] = context;
++
++            int scansBefore = ScoutStats(11);
++            Assert.Equal(NotQuiescent, Force(context));
++            GcQuiesce();
++
++            Assert.True(ScoutStats(11) > scansBefore,
++                $"the scan did not report with a large reference array live: kind 11 was {scansBefore}, now {ScoutStats(11)}. An unbounded per-slot cost would show up here as a hang or an abort rather than a missing report, so this failing at all is worth reading carefully.");
++
++            Assert.True(ScoutStats(12) > 0,
++                $"kind 12 (edges) is {ScoutStats(12)}: the array holding the condemned wrapper produced no edge, so either the slot budget cut the walk short before reaching it or the element was not scanned.");
++
++            GC.KeepAlive(rooted);
++            GC.KeepAlive(wide);
++            GC.KeepAlive(filler);
++        }
++
          [Fact]
          public async Task ForceNativeUnload_AfterCompleted_ManagedLoadApisReject()
          {
 diff --git a/src/mono/mono/metadata/assembly-load-context.c b/src/mono/mono/metadata/assembly-load-context.c
-index 1054345..a6cace8 100644
+index 1054345..d1db809 100644
 --- a/src/mono/mono/metadata/assembly-load-context.c
 +++ b/src/mono/mono/metadata/assembly-load-context.c
-@@ -515,6 +515,220 @@ alc_condemned_snapshot_fill (gint32 *fields, gint32 length, gint32 slot_budget)
+@@ -515,6 +515,266 @@ alc_condemned_snapshot_fill (gint32 *fields, gint32 length, gint32 slot_budget)
  	return ALC_SNAPSHOT_FIELD_COUNT;
  }
  
@@ -244,10 +389,18 @@ index 1054345..a6cace8 100644
 + * witnesses are nevertheless reachable, so the reference runs through the object graph -- and no
 + * amount of further handle classification can follow a graph.
 + *
-+ * WHAT THIS MEASURES. One bounded pass over the heap with the world already stopped, reporting
-+ * for each condemned witness the CLASS of the objects that reference it, plus the field offset
-+ * of the reference. That is the reverse of the snapshot's question, and it names the holder
-+ * directly instead of narrowing the search space.
++ * WHAT THIS MEASURES. Two bounded passes with the mutators still suspended, reporting for each
++ * condemned witness the CLASS of the objects that reference it, plus the field offset of the
++ * reference. That is the reverse of the snapshot's question, and it names the holder directly
++ * instead of narrowing the search space.
++ *
++ * TWO passes, because one is not exhaustive. The heap walk is descriptor-driven, and sgen zeroes
++ * the GC descriptor bitmap for System.Runtime.Ephemeron, so a ConditionalWeakTable or
++ * DependentHandle value edge is invisible to it -- while being a genuine root, since
++ * sgen_client_mark_ephemerons marks the value whenever the key is alive. A witness held only
++ * that way would otherwise produce an unsaturated EMPTY report, which is the one reading this
++ * surface must never get wrong. The second pass walks ephemeron_list and reports those edges
++ * marked as dependent, with the KEY as the referrer.
 + *
 + * WHEN IT RUNS -- and why it is not synchronous. The interesting moment is a REFUSAL: the
 + * quiescence gate answering not-quiescent is the only evidence that a witness is still held.
@@ -296,11 +449,32 @@ index 1054345..a6cace8 100644
 + * has to be read consistently with anything else. */
 +static gint32 alc_referrer_scans_reported;
 +
-+/* Objects whose reference fields the pause-time walk may examine. Sized so the walk costs a
-+ * bounded slice of a pause on the heaps this diagnostic runs against, in the same spirit as
-+ * ALC_CONDEMNED_HANDLE_SLOT_BUDGET: large enough to cover a stranding repro's heap, small
-+ * enough that saturation gets reported rather than silently paid for. */
++/* Referencing EDGES found by the most recently reported scan, and how many of those were
++ * DEPENDENT edges (ephemeron key->value). Exposed as stat kinds 12 and 13 so a regression can
++ * prove the dependent-edge pass finds an edge that descriptor scanning cannot see -- without
++ * them, a ConditionalWeakTable blind spot would be invisible to every test, which is exactly the
++ * gap that let two wrong assertions ship. Last-scan values rather than monotonic totals: the
++ * question a test asks is "what did THAT scan find", and kind 11 is the monotonic companion that
++ * says whether a new scan has happened at all. Read kind 11 before and after to know which scan
++ * these describe -- they are independent gauges, not a tuple. */
++static gint32 alc_referrer_last_edges;
++static gint32 alc_referrer_last_dependent_edges;
++
++/* Objects the pause-time walk may ENTER for reference scanning. Large enough to cover a
++ * stranding repro's heap, small enough that saturation is reported rather than silently paid
++ * for. */
 +#define ALC_REFERRER_SCAN_OBJECT_BUDGET 400000
++
++/* Reference slots the walk may LOOK UP, across every object entered and the ephemeron pass. This
++ * is the budget that bounds the dominant cost; the object budget above bounds only how many
++ * objects are entered, and one large array can carry millions of slots by itself.
++ *
++ * Deliberately NOT described as bounding the pause. It does not: the heap enumeration (including
++ * the forced major sweep) is unbounded, and the slot enumeration WITHIN an object already entered
++ * cannot be interrupted. See reference_slot_budget on MonoSgenCondemnedReferrerScan, which states
++ * precisely what each budget does and does not cover -- an earlier revision of this comment
++ * claimed a "bounded slice of a pause", which was not true of either budget. */
++#define ALC_REFERRER_SCAN_SLOT_BUDGET 2000000
 +
 +/* Explicit, separate opt-in on top of MONO_WASM_ENABLE_ALC_UNLOAD (see DOUBLE OPT-IN above).
 + * Read once: an env lookup must not be repeated inside a GC pause. */
@@ -401,29 +575,46 @@ index 1054345..a6cace8 100644
 +	memset (&scan, 0, sizeof (scan));
 +	scan.condemned_objects = objects;
 +	scan.object_budget = ALC_REFERRER_SCAN_OBJECT_BUDGET;
++	scan.reference_slot_budget = ALC_REFERRER_SCAN_SLOT_BUDGET;
 +	sgen_scan_referrers_of_condemned (&scan);
 +
 +	/* One summary line, then one line per described referrer. The summary carries the figures
 +	 * that qualify the rows -- and that qualify their ABSENCE, which is the reading mistake
 +	 * this diagnostic is most likely to invite. */
 +	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY,
-+		"[alc-referrers] witnesses=%u referenced=%d edges=%d described=%d objects=%d/%d saturated=%d",
++		"[alc-referrers] witnesses=%u referenced=%d edges=%d described=%d objects=%d/%d slots=%d/%d ephemerons=%d saturated=%d",
 +		g_hash_table_size (objects), scan.witnesses_referenced, scan.referrer_edges,
 +		scan.referrers_recorded, scan.objects_scanned, scan.objects_visited,
-+		scan.saturated ? 1 : 0);
++		scan.reference_slots_visited, ALC_REFERRER_SCAN_SLOT_BUDGET,
++		scan.ephemeron_entries_visited, scan.saturated ? 1 : 0);
 +
 +	for (gint32 i = 0; i < scan.referrers_recorded; ++i) {
 +		MonoSgenCondemnedReferrer *row = &scan.referrers [i];
++		/* "<-" is an ordinary reference, "<=" a DEPENDENT one (the witness is the value of a
++		 * live ephemeron key: a ConditionalWeakTable or DependentHandle). The distinction is the
++		 * whole point of the second pass, so it must survive into the output -- and for a
++		 * dependent row the trailing number is the ephemeron INDEX, not a field offset. */
 +		mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY,
-+			"[alc-referrers]   witness=%p <- %s.%s[%p] +%u",
++			"[alc-referrers]   witness=%p %s %s.%s[%p] %s%u",
 +			row->witness,
++			row->dependent ? "<=" : "<-",
 +			row->referrer_klass_namespace ? row->referrer_klass_namespace : "?",
 +			row->referrer_klass_name ? row->referrer_klass_name : "?",
-+			row->referrer, row->field_offset);
++			row->referrer,
++			row->dependent ? "idx=" : "+",
++			row->field_offset);
 +	}
 +
 +	/* AFTER the report: the counter's promise is that the summary and any rows were emitted, so
-+	 * a test observing it knows the walk happened rather than merely that a request existed. */
++	 * a test observing it knows the walk happened rather than merely that a request existed.
++	 * The last-scan gauges are published BEFORE that counter is bumped, so a reader that sees a
++	 * new kind 11 is guaranteed to be looking at this scan's figures and not the previous one's. */
++	alc_referrer_last_edges = scan.referrer_edges;
++	alc_referrer_last_dependent_edges = 0;
++	for (gint32 i = 0; i < scan.referrers_recorded; ++i) {
++		if (scan.referrers [i].dependent)
++			alc_referrer_last_dependent_edges++;
++	}
 +	alc_referrer_scans_reported++;
 +
 +	g_hash_table_destroy (objects);
@@ -437,7 +628,7 @@ index 1054345..a6cace8 100644
  static void
  retired_scout_targets_add (MonoMemoryManager *memory_manager)
  {
-@@ -953,8 +1167,14 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
+@@ -953,8 +1213,14 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
  	if (!alc->unloading)
  		return FORCE_UNLOAD_REJECTED;
  
@@ -453,7 +644,7 @@ index 1054345..a6cace8 100644
  
  	mono_alc_free (alc);
  	return FORCE_UNLOAD_COMPLETED;
-@@ -1032,7 +1252,14 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+@@ -1032,7 +1298,22 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
  	 * scout ran and refused" from "the scout never ran": a never-dying witness climbs this
  	 * counter while kind 7 stays flat.
  	 *
@@ -465,24 +656,36 @@ index 1054345..a6cace8 100644
 +	 * NOT a field of a tuple, so it carries none of the cross-read consistency requirements that
 +	 * shaped the snapshot below.
 +	 *
-+	 * Kinds 12-24 DO NOT EXIST: the condemned-set root classification is not a family of stat
++	 * Kinds 12 and 13 — referencing EDGES found by the most recently REPORTED referrer scan, and
++	 * how many of those were DEPENDENT edges (ephemeron key->value, i.e. a ConditionalWeakTable or
++	 * DependentHandle). Kind 13 exists so a regression can prove the dependent-edge pass sees an
++	 * edge that descriptor scanning structurally cannot: sgen zeroes the GC bitmap for
++	 * System.Runtime.Ephemeron, so without that pass such a witness produces an empty report.
++	 * These are LAST-SCAN values, not monotonic; read kind 11 around them to know which scan they
++	 * describe. Independent gauges, not a tuple.
++	 *
++	 * Kinds 14-24 DO NOT EXIST: the condemned-set root classification is not a family of stat
  	 * kinds at all. It is delivered as one whole tuple by InternalGetCondemnedSnapshot, for the
  	 * reasons in the "Root classification for condemned collectible contexts" block at the top
  	 * of this file, which is its only contract. Unknown kinds keep returning -1 here.
-@@ -1072,6 +1299,8 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+@@ -1072,6 +1353,12 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
  		return collectible_alc_native_structs;
  	case 10:
  		return scout_completion_deferral_count;
 +	case 11:
 +		return alc_referrer_scans_reported;
++	case 12:
++		return alc_referrer_last_edges;
++	case 13:
++		return alc_referrer_last_dependent_edges;
  	default:
  		return -1;
  	}
 diff --git a/src/mono/mono/metadata/gc-internals.h b/src/mono/mono/metadata/gc-internals.h
-index 1c51c11..b9f99a2 100644
+index 1c51c11..01a182b 100644
 --- a/src/mono/mono/metadata/gc-internals.h
 +++ b/src/mono/mono/metadata/gc-internals.h
-@@ -490,6 +490,97 @@ typedef struct {
+@@ -490,6 +490,144 @@ typedef struct {
  } MonoSgenCondemnedHandleScan;
  
  void sgen_scan_handles_into_managers (MonoSgenCondemnedHandleScan *scan);
@@ -501,21 +704,40 @@ index 1c51c11..b9f99a2 100644
 + * the referrers themselves.
 + *
 + * PRECONDITION, and the reason this one differs from its sibling: the heap walk is only legal
-+ * with the world already STOPPED and the collection finished, i.e. from the
-+ * MONO_GC_EVENT_PRE_START_WORLD point (see mono_gc_walk_heap's own contract in sgen-mono.c),
-+ * and it asserts sgen_is_world_stopped (). The handle scan runs with the world RUNNING instead,
-+ * from an ordinary icall, because it only reads handle slots and must not be able to observe a
-+ * collector mid-rewrite. Note that BOTH points see sgen_current_collection_generation == -1 --
-+ * sgen clears it before restarting the world -- so the generation cannot tell them apart and
-+ * neither assertion is phrased in terms of it.
++ * with the mutators still suspended and the collection finished, i.e. from the
++ * MONO_GC_EVENT_PRE_START_WORLD point (see mono_gc_walk_heap's own contract in sgen-mono.c).
++ * The handle scan runs with the world RUNNING instead, from an ordinary icall, because it only
++ * reads handle slots and must not observe a collector mid-rewrite.
++ *
++ * It is NOT asserted, and neither of the two predicates one would reach for says what it looks
++ * like it says at this point -- both read the same at the hook as they do outside a collection:
++ * sgen clears sgen_current_collection_generation before restarting, and sgen_restart_world
++ * clears world_is_stopped BEFORE calling sgen_client_restart_world, so sgen_is_world_stopped ()
++ * is already FALSE while the mutators are still suspended. The definition in sgen-mono.c
++ * records both dead ends; do not reintroduce either assertion.
++ *
++ * COMPLETENESS, which is what an unsaturated EMPTY result rests on. Descriptor scanning alone is
++ * NOT exhaustive: sgen deliberately zeroes the GC bitmap for System.Runtime.Ephemeron (object.c,
++ * "An Ephemeron cannot be marked by sgen"), so a ConditionalWeakTable / DependentHandle value
++ * edge is invisible to every descriptor-driven walk, including this one. Those edges are real --
++ * sgen_client_mark_ephemerons marks the value while the key is alive -- so a witness held only
++ * as a dependent value would produce an unsaturated empty report and directly contradict the
++ * contract. The scan therefore runs a SECOND pass over ephemeron_list at the same stopped-world
++ * point and reports those edges with `dependent` set. Root classes the collector marks outside
++ * object descriptors and outside ephemerons -- thread stacks and registers, native structures --
++ * remain outside this walk, and outside what an empty result can claim.
 + */
 +
 +/* Referrers described per witness before further hits on that witness are counted but not
 + * described. Small on purpose: the question is "what CLASS of thing holds this", and the first
 + * few answers settle it -- an unbounded list would turn a diagnostic into a heap dump. */
 +#define MONO_SGEN_CONDEMNED_REFERRERS_PER_WITNESS 4
-+/* Distinct witnesses described per scan. A stranding repro accumulates one witness per cycle
-+ * and the referrer SHAPE repeats, so describing the first few is what identifies the holder. */
++/* Distinct witnesses ADMITTED for description per scan. A stranding repro accumulates one
++ * witness per cycle and the referrer SHAPE repeats, so describing the first few is what
++ * identifies the holder. This is an ENFORCED admission cap, not merely a factor in the array
++ * size below: once this many distinct witnesses hold rows, later ones are still COUNTED (in
++ * referrer_edges and witnesses_referenced) but receive none, so 32 witnesses with a single edge
++ * each cannot quietly consume the whole row array while this comment promises eight. */
 +#define MONO_SGEN_CONDEMNED_WITNESSES_REPORTED 8
 +
 +typedef struct {
@@ -529,8 +751,17 @@ index 1c51c11..b9f99a2 100644
 +	const char *referrer_klass_name;
 +	const char *referrer_klass_namespace;
 +	/* Byte offset of the referencing field within the referrer, as reported by the object
-+	 * scanner. Cheap to carry, and it separates "a field of X" from "an element of X". */
++	 * scanner. Cheap to carry, and it separates "a field of X" from "an element of X". For a
++	 * dependent edge (see `dependent`) it is the ephemeron's INDEX within its array instead: a
++	 * byte offset into a struct whose fields the collector reports none of would be meaningless.
++	 */
 +	guint32 field_offset;
++	/* TRUE when the row came from the ephemeron pass rather than descriptor scanning: the witness
++	 * is the dependent VALUE of a live key, i.e. reached through a ConditionalWeakTable or
++	 * DependentHandle. `referrer` is then the KEY, which is the identity worth having -- "alive
++	 * exactly as long as this key is" -- rather than the ephemeron array that happens to hold
++	 * the pair. */
++	gboolean dependent;
 +} MonoSgenCondemnedReferrer;
 +
 +typedef struct {
@@ -539,20 +770,32 @@ index 1c51c11..b9f99a2 100644
 +	 * inside the same pause: a set built earlier cannot be carried across a collection, because
 +	 * a moving collector relocates its members. */
 +	GHashTable *condemned_objects;
-+	/* IN: cap on objects whose REFERENCE FIELDS are examined. MUST be > 0 (asserted).
-+	 *
-+	 * READ THIS BEFORE TRUSTING AN EMPTY RESULT. The cap bounds the per-object REFERENCE SCAN
-+	 * and NOT the object enumeration, because sgen's heap iterators (sgen_scan_area_with_callback,
-+	 * the major collector's iterate_objects, sgen_los_iterate_objects) run to completion and
-+	 * their callbacks cannot stop them. So a scan costs a full enumeration of the heap -- which
-+	 * includes forcing the major collector to finish sweeping, since the walk passes
-+	 * ITERATE_OBJECTS_SWEEP_ALL exactly as mono_gc_walk_heap does, and that is NOT free on a
-+	 * lazily-swept heap -- plus at most `object_budget` reference scans on top. The budget bounds
-+	 * the second half only; it is not a bound on the whole operation and must not be read as one.
-+	 * Once it is spent, later objects are COUNTED but not examined, `saturated` is set, and every
-+	 * count below becomes a LOWER BOUND: an empty referrer list from a saturated scan says
-+	 * nothing at all. */
++	/* IN: cap on the NUMBER OF OBJECTS entered for reference scanning. MUST be > 0 (asserted).
++	 * This bounds how many objects are entered and says nothing about what each one costs -- see
++	 * reference_slot_budget, which is the bound that actually matters. */
 +	gint32 object_budget;
++	/* IN: cap on REFERENCE SLOTS looked up, across every object entered and the ephemeron pass.
++	 * MUST be > 0 (asserted).
++	 *
++	 * This exists because object_budget alone bounded nothing expensive. The per-object scan
++	 * invokes the reference callback once per reference -- once per ELEMENT for a vector or
++	 * complex array -- so one large object[] costs a single object unit while performing
++	 * millions of pointer loads and set lookups on the browser's one suspended thread. That is
++	 * the same defect shape as bounding a handle walk on classified hits rather than raw slots.
++	 *
++	 * WHAT IT BOUNDS AND WHAT IT DOES NOT, stated narrowly because "the pause is bounded" would
++	 * be false:
++	 *   - It bounds the SET LOOKUPS, the dominant per-slot cost, across the whole scan rather
++	 *     than per object.
++	 *   - It does NOT interrupt the enumeration of one object's slots. sgen-scan-object.h expands
++	 *     to a loop this code cannot break out of, so every object entered pays all of its own
++	 *     pointer loads even with the budget already spent.
++	 *   - It does NOT bound the object enumeration (see object_budget), nor the forced major
++	 *     sweep from ITERATE_OBJECTS_SWEEP_ALL, which mono_gc_walk_heap also performs.
++	 * A scan therefore costs: a full heap enumeration including that sweep, plus the intra-object
++	 * slot loads of every object entered, plus at most `reference_slot_budget` lookups. It is not
++	 * a bound on total pause work and must not be read as one. */
++	gint32 reference_slot_budget;
 +
 +	/* OUT: referrer rows, filled in discovery order up to the caps above. */
 +	MonoSgenCondemnedReferrer referrers [MONO_SGEN_CONDEMNED_WITNESSES_REPORTED * MONO_SGEN_CONDEMNED_REFERRERS_PER_WITNESS];
@@ -569,10 +812,17 @@ index 1c51c11..b9f99a2 100644
 +	 * iterators always run to completion (see object_budget), so no denominator is fabricated. */
 +	gint32 objects_visited;
 +	/* OUT: objects whose reference fields were actually examined, i.e. the part of
-+	 * objects_visited the budget paid for. */
++	 * objects_visited that object_budget paid for. */
 +	gint32 objects_scanned;
-+	/* OUT: TRUE when objects_scanned < objects_visited, i.e. the budget ran out and the search
-+	 * is incomplete (see object_budget). */
++	/* OUT: reference slots for which a set lookup was performed, the ephemeron pass included.
++	 * Bounded by reference_slot_budget. */
++	gint32 reference_slots_visited;
++	/* OUT: ephemeron entries examined -- live-keyed entries of live ephemeron arrays. Reported
++	 * separately because zero here alongside a non-empty heap walk means the dependent-edge pass
++	 * had nothing to look at, which is a different statement from finding no dependent edge. */
++	gint32 ephemeron_entries_visited;
++	/* OUT: TRUE when EITHER budget ran out. The search is then incomplete, every count above is
++	 * a LOWER BOUND, and an empty referrer list says nothing at all. */
 +	gboolean saturated;
 +} MonoSgenCondemnedReferrerScan;
 +
@@ -607,10 +857,10 @@ index 4275a39..4a3191e 100644
  mono_mem_manager_new (MonoAssemblyLoadContext **alcs, int nalcs, gboolean collectible);
  
 diff --git a/src/mono/mono/metadata/sgen-mono.c b/src/mono/mono/metadata/sgen-mono.c
-index fd4e6e5..a331fc7 100644
+index fd4e6e5..8249739 100644
 --- a/src/mono/mono/metadata/sgen-mono.c
 +++ b/src/mono/mono/metadata/sgen-mono.c
-@@ -2064,6 +2064,193 @@ sgen_scan_handles_into_managers (MonoSgenCondemnedHandleScan *scan)
+@@ -2064,6 +2064,294 @@ sgen_scan_handles_into_managers (MonoSgenCondemnedHandleScan *scan)
  
  	sgen_condemned_scan_in_progress = FALSE;
  }
@@ -642,12 +892,39 @@ index fd4e6e5..a331fc7 100644
 +static gboolean sgen_referrer_scan_in_progress;
 +
 +/* Per-witness description budget. Keyed on the witness pointer, value is the number of rows
-+ * already emitted for it, so the caps in gc-internals.h are enforced per witness rather than
-+ * letting one heavily-referenced object consume every row. */
++ * already emitted for it PLUS ONE, so the caps in gc-internals.h are enforced per witness rather
++ * than letting one heavily-referenced object consume every row. The +1 bias makes "seen but
++ * described zero times" representable; see sgen_referrer_record. */
 +static GHashTable *sgen_referrer_scan_described;
 +
++/* Distinct witnesses ADMITTED for description so far. Enforces
++ * MONO_SGEN_CONDEMNED_WITNESSES_REPORTED, which without this was only a factor in the row-array
++ * size: 32 witnesses with one edge each would each get a row and exhaust the array, while the
++ * contract said eight. Witnesses beyond the cap are still counted, just not described. */
++static gint32 sgen_referrer_scan_witnesses_admitted;
++
++/*
++ * Charge one reference slot against the budget. Returns FALSE once the budget is spent, at which
++ * point the caller must skip the lookup -- the expensive part -- and the scan is saturated. The
++ * counter is incremented only when the charge succeeds, so reference_slots_visited means "slots
++ * we actually looked up" and never "slots we walked past".
++ */
++static gboolean
++sgen_referrer_charge_slot (void)
++{
++	MonoSgenCondemnedReferrerScan *scan = sgen_referrer_scan_current;
++
++	if (scan->reference_slots_visited >= scan->reference_slot_budget) {
++		scan->saturated = TRUE;
++		return FALSE;
++	}
++
++	scan->reference_slots_visited++;
++	return TRUE;
++}
++
 +static void
-+sgen_referrer_record (GCObject *referrer, GCObject *witness, uintptr_t offset)
++sgen_referrer_record (GCObject *referrer, GCObject *witness, uintptr_t offset, gboolean dependent)
 +{
 +	MonoSgenCondemnedReferrerScan *scan = sgen_referrer_scan_current;
 +
@@ -668,8 +945,17 @@ index fd4e6e5..a331fc7 100644
 +
 +	if (!prior) {
 +		scan->witnesses_referenced++;
-+		/* Mark seen BEFORE either cap below can return early. */
++		/* Mark seen BEFORE any cap below can return early. */
 +		g_hash_table_insert (sgen_referrer_scan_described, witness, GUINT_TO_POINTER (1));
++		/* Admission: a NEW witness only gets rows while there is room in the distinct-witness
++		 * cap. Counted above regardless, so the totals stay honest past the cap. */
++		if (sgen_referrer_scan_witnesses_admitted >= MONO_SGEN_CONDEMNED_WITNESSES_REPORTED)
++			return;
++		sgen_referrer_scan_witnesses_admitted++;
++	} else if (described == 0) {
++		/* Seen before but never admitted: it lost the admission race above and stays undescribed
++		 * for the rest of the scan rather than sneaking rows in on a later edge. */
++		return;
 +	}
 +
 +	if (described >= MONO_SGEN_CONDEMNED_REFERRERS_PER_WITNESS)
@@ -681,6 +967,7 @@ index fd4e6e5..a331fc7 100644
 +	row->witness = witness;
 +	row->referrer = referrer;
 +	row->field_offset = (guint32)offset;
++	row->dependent = dependent;
 +
 +	/* NULL-safe on purpose: a referrer whose vtable or class cannot be read is still worth
 +	 * reporting as an edge, and this is a diagnostic that must not be able to abort the runtime
@@ -694,11 +981,22 @@ index fd4e6e5..a331fc7 100644
 +	g_hash_table_insert (sgen_referrer_scan_described, witness, GUINT_TO_POINTER (described + 2));
 +}
 +
++/*
++ * One reference slot. The lookup is charged to reference_slot_budget HERE rather than per
++ * object, because this is what a large array actually costs: sgen-scan-object.h expands to a
++ * loop over every element and calls this macro for each one. Once the budget is spent the
++ * lookups stop and the scan is marked saturated; the loop itself cannot be broken out of, so
++ * the pointer loads of an object already entered still happen (stated in gc-internals.h).
++ */
 +#undef HANDLE_PTR
 +#define HANDLE_PTR(ptr,obj)	do {	\
 +		GCObject *__ref = *(ptr);	\
-+		if (__ref && g_hash_table_contains (sgen_referrer_scan_current->condemned_objects, __ref))	\
-+			sgen_referrer_record ((GCObject*)start, __ref, (char*)(ptr) - (char*)start);	\
++		if (__ref) {	\
++			if (!sgen_referrer_charge_slot ())	\
++				break;	\
++			if (g_hash_table_contains (sgen_referrer_scan_current->condemned_objects, __ref))	\
++				sgen_referrer_record ((GCObject*)start, __ref, (char*)(ptr) - (char*)start, FALSE);	\
++		}	\
 +	} while (0)
 +
 +static void
@@ -747,6 +1045,8 @@ index fd4e6e5..a331fc7 100644
 +	scan->witnesses_referenced = 0;
 +	scan->objects_visited = 0;
 +	scan->objects_scanned = 0;
++	scan->reference_slots_visited = 0;
++	scan->ephemeron_entries_visited = 0;
 +	scan->saturated = FALSE;
 +
 +	/* Nothing to find referrers of: skip the sweep entirely rather than walking the whole heap
@@ -779,10 +1079,12 @@ index fd4e6e5..a331fc7 100644
 +	 * inside a GC pause on the single browser thread must carry a bound by construction, so a
 +	 * non-positive budget is a caller bug rather than a mode. */
 +	g_assert (scan->object_budget > 0);
++	g_assert (scan->reference_slot_budget > 0);
 +
 +	sgen_referrer_scan_in_progress = TRUE;
 +	sgen_referrer_scan_current = scan;
 +	sgen_referrer_scan_described = g_hash_table_new (g_direct_hash, g_direct_equal);
++	sgen_referrer_scan_witnesses_admitted = 0;
 +
 +	/*
 +	 * The same three regions mono_gc_walk_heap covers, in the same order, because between them
@@ -796,8 +1098,57 @@ index fd4e6e5..a331fc7 100644
 +	sgen_major_collector.iterate_objects (ITERATE_OBJECTS_SWEEP_ALL, sgen_referrer_visit_object, scan);
 +	sgen_los_iterate_objects (sgen_referrer_visit_object, scan);
 +
++	/*
++	 * SECOND PASS: dependent edges, which the three passes above CANNOT see.
++	 *
++	 * sgen zeroes the GC bitmap for System.Runtime.Ephemeron (object.c, "An Ephemeron cannot be
++	 * marked by sgen"), so an ephemeron array's descriptor reports no references and every
++	 * descriptor-driven walk -- including this one -- misses the key->value edge entirely. The
++	 * edge is nonetheless a real root: sgen_client_mark_ephemerons marks the value whenever the
++	 * key is alive, which is exactly how a ConditionalWeakTable or DependentHandle keeps its
++	 * value reachable. Without this pass a witness held only as a dependent value would produce
++	 * an UNSATURATED EMPTY report, contradicting the one thing an empty report is supposed to
++	 * mean.
++	 *
++	 * The liveness test and the tombstone skip mirror sgen_client_mark_ephemerons so that this
++	 * pass reports the same edges the collector actually traverses -- a dead key's value is not
++	 * a root, and reporting it would invent a holder. The referrer recorded is the KEY, since
++	 * "alive as long as this key is" is the actionable identity; the array is not.
++	 */
++	for (EphemeronLinkNode *current = ephemeron_list; current; current = current->next) {
++		MonoArray *array = current->array;
++		if (!array || !sgen_is_object_alive_for_current_gen ((GCObject*)array))
++			continue;
++
++		Ephemeron *cur = mono_array_addr_internal (array, Ephemeron, 0);
++		Ephemeron *array_end = cur + mono_array_length_internal (array);
++		GCObject *tombstone = SGEN_LOAD_VTABLE ((GCObject*)array)->domain->ephemeron_tombstone;
++
++		for (; cur < array_end; ++cur) {
++			GCObject *key = cur->key;
++			if (!key || key == tombstone)
++				continue;
++			if (!sgen_is_object_alive_for_current_gen (key))
++				continue;
++
++			GCObject *value = cur->value;
++			if (!value)
++				continue;
++
++			/* Charged like any other reference slot, so one enormous CWT cannot cost more than
++			 * the budget allows. */
++			if (!sgen_referrer_charge_slot ())
++				break;
++
++			scan->ephemeron_entries_visited++;
++			if (g_hash_table_contains (scan->condemned_objects, value))
++				sgen_referrer_record (key, value, (guint32)(cur - mono_array_addr_internal (array, Ephemeron, 0)), TRUE);
++		}
++	}
++
 +	g_hash_table_destroy (sgen_referrer_scan_described);
 +	sgen_referrer_scan_described = NULL;
++	sgen_referrer_scan_witnesses_admitted = 0;
 +	sgen_referrer_scan_current = NULL;
 +	sgen_referrer_scan_in_progress = FALSE;
 +}

--- a/patches/0015-report-referrers-of-condemned-collectible-alc-witnesses.patch
+++ b/patches/0015-report-referrers-of-condemned-collectible-alc-witnesses.patch
@@ -142,7 +142,16 @@ MONO_WASM_ALC_UNLOAD_REFERRER_SCAN=1 -- the only leg that arms this code:
     unbounded per-slot cost would surface.
 
 Each asserts the refusal itself rather than tolerating a Completed, since a
-Completed would make the rest vacuous.
+Completed would make the rest vacuous, and each then drives its context
+TERMINAL. That last part is not tidiness: this suite has a standing invariant
+that every test leaves no context pending -- stated in
+Unload_DroppedRootsWithoutAnyForcedAttempt's own comment and asserted through
+PendingUnloadsGauge -- and a first revision of these three sustained their
+refusals past the end of the test, which failed two OTHER tests. The refusal
+half of each now lives in its own non-inlined frame so the rooting probe (and
+the CWT, and the wide array) are unreachable before the teardown runs, which a
+local in the test's frame would not reliably be: the interpreter scans its live
+slot region conservatively.
 
 Temporary diagnostic scaffolding on the same terms and the same tracking
 issue (#176) as the snapshot it complements: it retires when the residual
@@ -150,16 +159,16 @@ root is found and fixed, or when the stop-rule fires.
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
 ---
- .../tests/ForcedNativeUnloadTests.cs          | 181 +++++++++++
- .../mono/metadata/assembly-load-context.c     | 291 +++++++++++++++++-
- src/mono/mono/metadata/gc-internals.h         | 138 +++++++++
+ .../tests/ForcedNativeUnloadTests.cs          | 232 ++++++++++++++
+ .../mono/metadata/assembly-load-context.c     | 292 ++++++++++++++++-
+ src/mono/mono/metadata/gc-internals.h         | 143 +++++++++
  src/mono/mono/metadata/loader-internals.h     |  15 +
- src/mono/mono/metadata/sgen-mono.c            | 288 +++++++++++++++++
+ src/mono/mono/metadata/sgen-mono.c            | 293 ++++++++++++++++++
  src/mono/mono/metadata/sgen-stw.c             |  16 +
- 6 files changed, 927 insertions(+), 2 deletions(-)
+ 6 files changed, 989 insertions(+), 2 deletions(-)
 
 diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
-index 2b2f170..3ef83c9 100644
+index 2b2f170..b51d33a 100644
 --- a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 +++ b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 @@ -178,6 +178,14 @@ private static bool FlagEnabled
@@ -177,7 +186,25 @@ index 2b2f170..3ef83c9 100644
          // Returns true (and the caller should no-op) only on a genuinely unpatched runtime. When CI
          // asserts the bridge must exist, a missing member fails loudly instead of self-skipping and
          // masking the regression.
-@@ -1585,6 +1593,179 @@ public async Task ForcedUnload_RootedPointerFreeObjects_BlockNativeFree()
+@@ -240,6 +248,17 @@ private static void GcQuiesce()
+         // Each NotQuiescent attempt must leave the once-only latch clear so a later attempt can
+         // still Complete — i.e. the single retry is never consumed by a premature force.
+         [MethodImpl(MethodImplOptions.NoInlining)]
++        // Restore the suite-wide invariant this file depends on: every test drives its contexts
++        // TERMINAL before returning, which is what lets Unload_DroppedRootsWithoutAnyForcedAttempt
++        // assert PendingUnloadsGauge == 0 and the population tests assert a return to baseline.
++        // The referrer-scan tests deliberately sustain a refusal, so they must undo it explicitly
++        // -- leaving a context pending fails two OTHER tests, which is how this was found.
++        private static async Task DriveTerminalAsync(AssemblyLoadContext context)
++        {
++            Assert.Equal(Completed, await ForceUntilCompletedAsync(context, 20));
++            await DrainRetiredScoutsAsync();
++        }
++
+         private static async Task<int> ForceUntilCompletedAsync(AssemblyLoadContext context, int maxAttempts)
+         {
+             int outcome = NotQuiescent;
+@@ -1585,6 +1604,219 @@ public async Task ForcedUnload_RootedPointerFreeObjects_BlockNativeFree()
              await RunConservativelyPinnedLosWitnessProtocol();
          }
  
@@ -197,8 +224,7 @@ index 2b2f170..3ef83c9 100644
 +        /// exists to identify.
 +        /// </summary>
 +        [Fact]
-+        [MethodImpl(MethodImplOptions.NoInlining)]
-+        public void ForcedUnload_ReferrerScan_RefusalIsServedAtNextCollection()
++        public async Task ForcedUnload_ReferrerScan_RefusalIsServedAtNextCollection()
 +        {
 +            if (BridgeMissing())
 +            {
@@ -218,16 +244,8 @@ index 2b2f170..3ef83c9 100644
 +            }
 +
 +            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
-+            object[] rooted = LoadUnloadReturningRootedPointerFreeProbe(context, losArray: true, new WeakReference[1]);
++            int after = RefuseAndReadScanCount(context, before);
 +
-+            // The refusal is the trigger. If this ever reports Completed the probe stopped rooting
-+            // the witness, which is a regression in its own right and would silently make the
-+            // assertions below vacuous -- so it is asserted rather than tolerated.
-+            Assert.Equal(NotQuiescent, Force(context));
-+
-+            GcQuiesce();
-+
-+            int after = ScoutStats(11);
 +            if (ReferrerScanRequested)
 +            {
 +                Assert.True(after > before,
@@ -238,9 +256,29 @@ index 2b2f170..3ef83c9 100644
 +                Assert.Equal(before, after);
 +            }
 +
-+            // The probe must outlive every assertion above: dropping it earlier would let the
-+            // witness die, clear the condemned set, and turn the refusal into a Completed.
++            // Undo the sustained refusal: see DriveTerminalAsync.
++            await DriveTerminalAsync(context);
++        }
++
++        // The refusal half of the referrer-scan tests, in its own NON-INLINED frame so the probe
++        // reference is confined to it. The probe has to root the witness across the Force and the
++        // serving collection, and must be UNREACHABLE afterwards so the caller can drive the
++        // context terminal -- which a local in the caller's frame would not reliably be, since the
++        // interpreter scans its live slot region conservatively.
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static int RefuseAndReadScanCount(AssemblyLoadContext context, int scansBefore)
++        {
++            object[] rooted = LoadUnloadReturningRootedPointerFreeProbe(context, losArray: true, new WeakReference[1]);
++
++            // If this ever reports Completed the probe stopped rooting the witness, which is a
++            // regression in its own right and would silently make the caller's assertions vacuous.
++            Assert.Equal(NotQuiescent, Force(context));
++
++            GcQuiesce();
++            int after = ScoutStats(11);
++
 +            GC.KeepAlive(rooted);
++            return after;
 +        }
 +
 +        /// <summary>
@@ -259,8 +297,7 @@ index 2b2f170..3ef83c9 100644
 +        /// point.
 +        /// </summary>
 +        [Fact]
-+        [MethodImpl(MethodImplOptions.NoInlining)]
-+        public void ForcedUnload_ReferrerScan_ReportsConditionalWeakTableDependentEdge()
++        public async Task ForcedUnload_ReferrerScan_ReportsConditionalWeakTableDependentEdge()
 +        {
 +            if (BridgeMissing())
 +            {
@@ -273,11 +310,29 @@ index 2b2f170..3ef83c9 100644
 +            }
 +
 +            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
++            (int scansBefore, int scansAfter, int dependentEdges, int totalEdges) = RefuseWithDependentEdge(context);
++
++            Assert.True(scansAfter > scansBefore,
++                $"no referrer scan was reported (kind 11 was {scansBefore}, now {scansAfter}), so the dependent-edge figures below would describe a different scan.");
++
++            Assert.True(dependentEdges > 0,
++                $"the ConditionalWeakTable dependent edge onto the condemned wrapper was not reported: kind 13 (dependent edges) is {dependentEdges} with kind 12 (total edges) at {totalEdges}. Descriptor scanning structurally cannot see this edge -- sgen zeroes the GC bitmap for Ephemeron -- so a zero here means the ephemeron pass did not run or did not match.");
++
++            await DriveTerminalAsync(context);
++        }
++
++        // Own non-inlined frame, for the reason given on RefuseAndReadScanCount, and here it also
++        // has to confine the CWT and its key: while either is reachable the dependent edge keeps
++        // the wrapper alive and the context cannot be driven terminal.
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static (int ScansBefore, int ScansAfter, int DependentEdges, int TotalEdges) RefuseWithDependentEdge(
++            AssemblyLoadContext context)
++        {
 +            object[] rooted = LoadUnloadReturningRootedPointerFreeProbe(context, losArray: true, new WeakReference[1]);
 +
-+            // The dependent edge: a live key whose VALUE is the condemned wrapper. The key must be
-+            // a distinct live object with no other path to the witness, so the only edge into the
-+            // witness from this table is the ephemeron one.
++            // The dependent edge: a live key whose VALUE is the condemned wrapper. The key is a
++            // distinct object with no other path to the witness, so the only edge into the witness
++            // from this table is the ephemeron one.
 +            var key = new object();
 +            var table = new ConditionalWeakTable<object, object>();
 +            table.Add(key, context);
@@ -286,18 +341,16 @@ index 2b2f170..3ef83c9 100644
 +            Assert.Equal(NotQuiescent, Force(context));
 +            GcQuiesce();
 +
-+            // Kind 11 must have advanced, or kinds 12/13 describe some earlier scan.
-+            Assert.True(ScoutStats(11) > scansBefore,
-+                $"no referrer scan was reported (kind 11 was {scansBefore}, now {ScoutStats(11)}), so the dependent-edge assertions below would describe a different scan.");
++            // Read every gauge BEFORE anything here becomes unreachable, so all three describe the
++            // same scan.
++            int scansAfter = ScoutStats(11);
++            int dependentEdges = ScoutStats(13);
++            int totalEdges = ScoutStats(12);
 +
-+            Assert.True(ScoutStats(13) > 0,
-+                $"the ConditionalWeakTable dependent edge onto the condemned wrapper was not reported: kind 13 (dependent edges) is {ScoutStats(13)} with kind 12 (total edges) at {ScoutStats(12)}. Descriptor scanning cannot see this edge, so a zero here means the ephemeron pass did not run or did not match.");
-+
-+            // Everything must outlive the assertions: dropping the table or the key would kill the
-+            // dependent edge, and dropping the probe would end the refusal.
 +            GC.KeepAlive(rooted);
 +            GC.KeepAlive(key);
 +            GC.KeepAlive(table);
++            return (scansBefore, scansAfter, dependentEdges, totalEdges);
 +        }
 +
 +        /// <summary>
@@ -312,8 +365,7 @@ index 2b2f170..3ef83c9 100644
 +        /// the budget's value rather than its existence.
 +        /// </summary>
 +        [Fact]
-+        [MethodImpl(MethodImplOptions.NoInlining)]
-+        public void ForcedUnload_ReferrerScan_LargeReferenceArrayStillReports()
++        public async Task ForcedUnload_ReferrerScan_LargeReferenceArrayStillReports()
 +        {
 +            if (BridgeMissing())
 +            {
@@ -326,11 +378,28 @@ index 2b2f170..3ef83c9 100644
 +            }
 +
 +            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
++            (int scansBefore, int scansAfter, int totalEdges) = RefuseWithWideReferenceArray(context);
++
++            Assert.True(scansAfter > scansBefore,
++                $"the scan did not report with a large reference array live: kind 11 was {scansBefore}, now {scansAfter}. An unbounded per-slot cost would surface here as a hang or an abort rather than a missing report, so this failing at all is worth reading carefully.");
++
++            Assert.True(totalEdges > 0,
++                $"kind 12 (edges) is {totalEdges}: the array holding the condemned wrapper produced no edge, so either the slot budget cut the walk short before reaching it or the element was not scanned.");
++
++            await DriveTerminalAsync(context);
++        }
++
++        // Own non-inlined frame: the wide array holds the condemned wrapper in its last element, so
++        // it roots the witness and must be unreachable before the caller drives the context
++        // terminal.
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        private static (int ScansBefore, int ScansAfter, int TotalEdges) RefuseWithWideReferenceArray(
++            AssemblyLoadContext context)
++        {
 +            object[] rooted = LoadUnloadReturningRootedPointerFreeProbe(context, losArray: true, new WeakReference[1]);
 +
-+            // A large reference array whose elements are non-null, so every element costs a slot
-+            // charge. One element points at the condemned wrapper, so the array is also a genuine
-+            // referrer and the walk cannot skip it as uninteresting.
++            // Every element non-null, so every element costs a slot charge. The last points at the
++            // condemned wrapper, making the array a genuine referrer the walk cannot skip.
 +            object[] wide = new object[200_000];
 +            object filler = new object();
 +            for (int i = 0; i < wide.Length; i++)
@@ -343,25 +412,23 @@ index 2b2f170..3ef83c9 100644
 +            Assert.Equal(NotQuiescent, Force(context));
 +            GcQuiesce();
 +
-+            Assert.True(ScoutStats(11) > scansBefore,
-+                $"the scan did not report with a large reference array live: kind 11 was {scansBefore}, now {ScoutStats(11)}. An unbounded per-slot cost would show up here as a hang or an abort rather than a missing report, so this failing at all is worth reading carefully.");
-+
-+            Assert.True(ScoutStats(12) > 0,
-+                $"kind 12 (edges) is {ScoutStats(12)}: the array holding the condemned wrapper produced no edge, so either the slot budget cut the walk short before reaching it or the element was not scanned.");
++            int scansAfter = ScoutStats(11);
++            int totalEdges = ScoutStats(12);
 +
 +            GC.KeepAlive(rooted);
 +            GC.KeepAlive(wide);
 +            GC.KeepAlive(filler);
++            return (scansBefore, scansAfter, totalEdges);
 +        }
 +
          [Fact]
          public async Task ForceNativeUnload_AfterCompleted_ManagedLoadApisReject()
          {
 diff --git a/src/mono/mono/metadata/assembly-load-context.c b/src/mono/mono/metadata/assembly-load-context.c
-index 1054345..d1db809 100644
+index 1054345..99895f5 100644
 --- a/src/mono/mono/metadata/assembly-load-context.c
 +++ b/src/mono/mono/metadata/assembly-load-context.c
-@@ -515,6 +515,266 @@ alc_condemned_snapshot_fill (gint32 *fields, gint32 length, gint32 slot_budget)
+@@ -515,6 +515,265 @@ alc_condemned_snapshot_fill (gint32 *fields, gint32 length, gint32 slot_budget)
  	return ALC_SNAPSHOT_FIELD_COUNT;
  }
  
@@ -582,9 +649,9 @@ index 1054345..d1db809 100644
 +	 * that qualify the rows -- and that qualify their ABSENCE, which is the reading mistake
 +	 * this diagnostic is most likely to invite. */
 +	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY,
-+		"[alc-referrers] witnesses=%u referenced=%d edges=%d described=%d objects=%d/%d slots=%d/%d ephemerons=%d saturated=%d",
++		"[alc-referrers] witnesses=%u referenced=%d edges=%d dependent=%d described=%d objects=%d/%d slots=%d/%d ephemerons=%d saturated=%d",
 +		g_hash_table_size (objects), scan.witnesses_referenced, scan.referrer_edges,
-+		scan.referrers_recorded, scan.objects_scanned, scan.objects_visited,
++		scan.dependent_edges, scan.referrers_recorded, scan.objects_scanned, scan.objects_visited,
 +		scan.reference_slots_visited, ALC_REFERRER_SCAN_SLOT_BUDGET,
 +		scan.ephemeron_entries_visited, scan.saturated ? 1 : 0);
 +
@@ -610,11 +677,10 @@ index 1054345..d1db809 100644
 +	 * The last-scan gauges are published BEFORE that counter is bumped, so a reader that sees a
 +	 * new kind 11 is guaranteed to be looking at this scan's figures and not the previous one's. */
 +	alc_referrer_last_edges = scan.referrer_edges;
-+	alc_referrer_last_dependent_edges = 0;
-+	for (gint32 i = 0; i < scan.referrers_recorded; ++i) {
-+		if (scan.referrers [i].dependent)
-+			alc_referrer_last_dependent_edges++;
-+	}
++	/* Straight from the scan, NOT recomputed from the described rows: an earlier revision counted
++	 * `dependent` rows in `referrers`, which reported 0 whenever the row or witness caps were
++	 * already spent -- so a dependent edge that WAS found could read as absent. */
++	alc_referrer_last_dependent_edges = scan.dependent_edges;
 +	alc_referrer_scans_reported++;
 +
 +	g_hash_table_destroy (objects);
@@ -628,7 +694,7 @@ index 1054345..d1db809 100644
  static void
  retired_scout_targets_add (MonoMemoryManager *memory_manager)
  {
-@@ -953,8 +1213,14 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
+@@ -953,8 +1212,14 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
  	if (!alc->unloading)
  		return FORCE_UNLOAD_REJECTED;
  
@@ -644,7 +710,7 @@ index 1054345..d1db809 100644
  
  	mono_alc_free (alc);
  	return FORCE_UNLOAD_COMPLETED;
-@@ -1032,7 +1298,22 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+@@ -1032,7 +1297,24 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
  	 * scout ran and refused" from "the scout never ran": a never-dying witness climbs this
  	 * counter while kind 7 stays flat.
  	 *
@@ -661,6 +727,8 @@ index 1054345..d1db809 100644
 +	 * DependentHandle). Kind 13 exists so a regression can prove the dependent-edge pass sees an
 +	 * edge that descriptor scanning structurally cannot: sgen zeroes the GC bitmap for
 +	 * System.Runtime.Ephemeron, so without that pass such a witness produces an empty report.
++	 * Both are EDGE counts taken from the scan itself, not row counts: the description caps must
++	 * never be able to make a found edge read as absent.
 +	 * These are LAST-SCAN values, not monotonic; read kind 11 around them to know which scan they
 +	 * describe. Independent gauges, not a tuple.
 +	 *
@@ -668,7 +736,7 @@ index 1054345..d1db809 100644
  	 * kinds at all. It is delivered as one whole tuple by InternalGetCondemnedSnapshot, for the
  	 * reasons in the "Root classification for condemned collectible contexts" block at the top
  	 * of this file, which is its only contract. Unknown kinds keep returning -1 here.
-@@ -1072,6 +1353,12 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+@@ -1072,6 +1354,12 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
  		return collectible_alc_native_structs;
  	case 10:
  		return scout_completion_deferral_count;
@@ -682,10 +750,10 @@ index 1054345..d1db809 100644
  		return -1;
  	}
 diff --git a/src/mono/mono/metadata/gc-internals.h b/src/mono/mono/metadata/gc-internals.h
-index 1c51c11..01a182b 100644
+index 1c51c11..747d1fc 100644
 --- a/src/mono/mono/metadata/gc-internals.h
 +++ b/src/mono/mono/metadata/gc-internals.h
-@@ -490,6 +490,144 @@ typedef struct {
+@@ -490,6 +490,149 @@ typedef struct {
  } MonoSgenCondemnedHandleScan;
  
  void sgen_scan_handles_into_managers (MonoSgenCondemnedHandleScan *scan);
@@ -806,6 +874,11 @@ index 1c51c11..01a182b 100644
 +	 * referrer_edges is a DESCRIPTION cap, not truncation of the search -- distinct from
 +	 * `saturated`, which reports the search itself being cut short. */
 +	gint32 referrer_edges;
++	/* OUT: of referrer_edges, how many were DEPENDENT edges (ephemeron key->value). Counted for
++	 * every such edge found, independent of whether a row was recorded for it -- the description
++	 * caps must not be able to make a found edge look absent, which is the whole reason this is
++	 * separate from counting `dependent` rows in `referrers`. */
++	gint32 dependent_edges;
 +	/* OUT: distinct condemned objects found to have at least one referrer. */
 +	gint32 witnesses_referenced;
 +	/* OUT: objects the heap iterators presented. This is the TRUE total, not an estimate: the
@@ -857,10 +930,10 @@ index 4275a39..4a3191e 100644
  mono_mem_manager_new (MonoAssemblyLoadContext **alcs, int nalcs, gboolean collectible);
  
 diff --git a/src/mono/mono/metadata/sgen-mono.c b/src/mono/mono/metadata/sgen-mono.c
-index fd4e6e5..8249739 100644
+index fd4e6e5..2a569d0 100644
 --- a/src/mono/mono/metadata/sgen-mono.c
 +++ b/src/mono/mono/metadata/sgen-mono.c
-@@ -2064,6 +2064,294 @@ sgen_scan_handles_into_managers (MonoSgenCondemnedHandleScan *scan)
+@@ -2064,6 +2064,299 @@ sgen_scan_handles_into_managers (MonoSgenCondemnedHandleScan *scan)
  
  	sgen_condemned_scan_in_progress = FALSE;
  }
@@ -929,8 +1002,12 @@ index fd4e6e5..8249739 100644
 +	MonoSgenCondemnedReferrerScan *scan = sgen_referrer_scan_current;
 +
 +	/* Every hit counts as an edge, described or not: the counts must stay honest even when the
-+	 * description caps hide the individual rows. */
++	 * description caps hide the individual rows. Dependent edges are counted the same way and
++	 * for the same reason -- a caller asking "did the ephemeron pass find anything" must not get
++	 * a zero merely because the row budget was already spent. */
 +	scan->referrer_edges++;
++	if (dependent)
++		scan->dependent_edges++;
 +
 +	/*
 +	 * The stored value is described + 1, so that "seen at all" and "seen but described zero
@@ -1042,6 +1119,7 @@ index fd4e6e5..8249739 100644
 +	memset (scan->referrers, 0, sizeof (scan->referrers));
 +	scan->referrers_recorded = 0;
 +	scan->referrer_edges = 0;
++	scan->dependent_edges = 0;
 +	scan->witnesses_referenced = 0;
 +	scan->objects_visited = 0;
 +	scan->objects_scanned = 0;

--- a/patches/0015-report-referrers-of-condemned-collectible-alc-witnesses.patch
+++ b/patches/0015-report-referrers-of-condemned-collectible-alc-witnesses.patch
@@ -97,9 +97,9 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
  .../mono/metadata/assembly-load-context.c     | 209 +++++++++++++++++-
  src/mono/mono/metadata/gc-internals.h         |  91 ++++++++
  src/mono/mono/metadata/loader-internals.h     |  15 ++
- src/mono/mono/metadata/sgen-mono.c            | 153 +++++++++++++
+ src/mono/mono/metadata/sgen-mono.c            | 176 +++++++++++++++
  src/mono/mono/metadata/sgen-stw.c             |  16 ++
- 5 files changed, 483 insertions(+), 1 deletion(-)
+ 5 files changed, 506 insertions(+), 1 deletion(-)
 
 diff --git a/src/mono/mono/metadata/assembly-load-context.c b/src/mono/mono/metadata/assembly-load-context.c
 index 1054345..a2abd44 100644
@@ -458,10 +458,10 @@ index 4275a39..4a3191e 100644
  mono_mem_manager_new (MonoAssemblyLoadContext **alcs, int nalcs, gboolean collectible);
  
 diff --git a/src/mono/mono/metadata/sgen-mono.c b/src/mono/mono/metadata/sgen-mono.c
-index fd4e6e5..7ed2fee 100644
+index fd4e6e5..cb69a5d 100644
 --- a/src/mono/mono/metadata/sgen-mono.c
 +++ b/src/mono/mono/metadata/sgen-mono.c
-@@ -2064,6 +2064,159 @@ sgen_scan_handles_into_managers (MonoSgenCondemnedHandleScan *scan)
+@@ -2064,6 +2064,182 @@ sgen_scan_handles_into_managers (MonoSgenCondemnedHandleScan *scan)
  
  	sgen_condemned_scan_in_progress = FALSE;
  }
@@ -506,10 +506,22 @@ index fd4e6e5..7ed2fee 100644
 +	 * description caps hide the individual rows. */
 +	scan->referrer_edges++;
 +
++	/*
++	 * The stored value is described + 1, so that "seen at all" and "seen but described zero
++	 * times" are DIFFERENT states. They diverge whenever a witness's first hit arrives once a
++	 * cap is already reached: no row is recorded for it, and if the entry were written only
++	 * alongside a row, that witness would read as unseen on its next hit and be counted again.
++	 * witnesses_referenced is a distinct-object count, so that would inflate it -- and the
++	 * inflation would be worst in exactly the heavily-referenced case the caps exist for.
++	 */
 +	gpointer prior = g_hash_table_lookup (sgen_referrer_scan_described, witness);
-+	guint described = prior ? GPOINTER_TO_UINT (prior) : 0;
-+	if (described == 0)
++	guint described = prior ? GPOINTER_TO_UINT (prior) - 1 : 0;
++
++	if (!prior) {
 +		scan->witnesses_referenced++;
++		/* Mark seen BEFORE either cap below can return early. */
++		g_hash_table_insert (sgen_referrer_scan_described, witness, GUINT_TO_POINTER (1));
++	}
 +
 +	if (described >= MONO_SGEN_CONDEMNED_REFERRERS_PER_WITNESS)
 +		return;
@@ -529,11 +541,16 @@ index fd4e6e5..7ed2fee 100644
 +	row->referrer_klass_name = klass ? m_class_get_name (klass) : NULL;
 +	row->referrer_klass_namespace = klass ? m_class_get_name_space (klass) : NULL;
 +
-+	g_hash_table_insert (sgen_referrer_scan_described, witness, GUINT_TO_POINTER (described + 1));
++	/* described + 1 rows now described, stored with the +1 bias above. */
++	g_hash_table_insert (sgen_referrer_scan_described, witness, GUINT_TO_POINTER (described + 2));
 +}
 +
 +#undef HANDLE_PTR
-+#define HANDLE_PTR(ptr,obj)	do {			GCObject *__ref = *(ptr);			if (__ref && g_hash_table_contains (sgen_referrer_scan_current->condemned_objects, __ref))				sgen_referrer_record ((GCObject*)start, __ref, (char*)(ptr) - (char*)start);		} while (0)
++#define HANDLE_PTR(ptr,obj)	do {	\
++		GCObject *__ref = *(ptr);	\
++		if (__ref && g_hash_table_contains (sgen_referrer_scan_current->condemned_objects, __ref))	\
++			sgen_referrer_record ((GCObject*)start, __ref, (char*)(ptr) - (char*)start);	\
++	} while (0)
 +
 +static void
 +sgen_referrer_scan_object (GCObject *obj)
@@ -543,6 +560,12 @@ index fd4e6e5..7ed2fee 100644
 +
 +#include "sgen/sgen-scan-object.h"
 +}
++
++/* Scoped to the one function above. The other two definitions in this file are each preceded by
++ * their own #undef, so leaving this one live would not have broken them -- but it is the last
++ * definition in the translation unit only by accident of ordering, and a later user would
++ * inherit a macro written for this scan's private statics. */
++#undef HANDLE_PTR
 +
 +static void
 +sgen_referrer_visit_object (GCObject *obj, size_t size, void *data)

--- a/patches/0015-report-referrers-of-condemned-collectible-alc-witnesses.patch
+++ b/patches/0015-report-referrers-of-condemned-collectible-alc-witnesses.patch
@@ -1,0 +1,657 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nick Randolph <noreply@platform.uno>
+Date: Tue, 25 Aug 2026 00:00:00 +0000
+Subject: [PATCH] feat: report which objects reference a condemned collectible
+ ALC witness
+
+The GC-handle classification added earlier answered its question in the
+negative. Across a downstream WASM host's stranding repro -- repeated
+collectible-ALC load/unload cycles with the forced-unload opt-in active --
+eight complete unsaturated sweeps report every handle bucket at 0 (strong,
+pinned and weak-track alike) while managers_in_scope equals live_witnesses
+exactly on every cycle and never decays:
+
+  cycle=1  managers=2  liveWitnesses=2  strong=0 pinned=0 weakTrack=0
+  cycle=8  managers=16 liveWitnesses=16 strong=0 pinned=0 weakTrack=0
+
+That rules out a GC handle DIRECTLY targeting a condemned object, which is
+all the snapshot can ever see: its attribution is one hop, so a handle on a
+container that merely references a witness is invisible to it. The witnesses
+are nevertheless reachable, so the reference runs through the object graph --
+and no amount of further handle classification can follow a graph.
+
+This adds the reverse lookup: one bounded pass over the heap that reports,
+for each condemned witness, the CLASS of the objects referencing it and the
+field offset of the reference. It names the holder instead of narrowing the
+search space.
+
+  * sgen_scan_referrers_of_condemned (sgen-mono.c) mirrors the three regions
+    mono_gc_walk_heap covers -- nursery, major heap, LOS -- with a scanner
+    that tests each reference in place against the condemned set. It does not
+    reuse mono_gc_walk_heap because that entry point buffers every reference
+    of every object through a MonoGCReferences callback with no budget and no
+    way for the callback to stop, the same shape problem
+    sgen_gchandle_foreach_slot_bounded was added to solve for the handle
+    tables; all this walk needs is one hash lookup per reference.
+  * assembly-load-context.c owns the trigger, the condemned set and the
+    report. A quiescence refusal is the only evidence a witness is still
+    held, so a refusal RECORDS A REQUEST; the next collection's
+    pre-start-world point serves it, because a heap walk is only legal with
+    the world stopped. Requests coalesce rather than queue, so a host that
+    retries in a loop gets one report rather than one per retry.
+  * sgen-stw.c calls the consumer at that point, before the profiler event,
+    under DISABLE_THREADS only.
+
+DOUBLE OPT-IN. MONO_WASM_ENABLE_ALC_UNLOAD does not arm this on its own; it
+also needs MONO_WASM_ALC_UNLOAD_REFERRER_SCAN. Unlike the snapshot -- a
+read-only gauge a caller chooses to poll -- this adds work to a collection
+pause, so a flagged session that has not asked for referrers pays one load
+and a branch.
+
+WHAT IT BOUNDS, AND WHAT IT DOES NOT. object_budget caps the per-object
+reference scan and NOT the object enumeration: sgen's iterators run to
+completion and their callbacks cannot stop them, and the walk passes
+ITERATE_OBJECTS_SWEEP_ALL exactly as mono_gc_walk_heap does, which forces a
+lazily-swept major heap to finish sweeping. So a scan costs a full
+enumeration plus at most object_budget reference scans, and the budget is a
+bound on the second half only. Because the iterators always finish,
+objects_visited is a TRUE total rather than an estimate, and
+objects_scanned/objects_visited plus `saturated` say exactly how much of the
+heap the answer covers.
+
+A referrer row is direct evidence. An EMPTY report is much weaker and means
+anything only when the scan did not saturate -- and the report is written to
+the assembly trace, so it is invisible without --trace=asm at info or finer.
+An empty console is therefore never evidence of anything, which the contract
+block says in those words.
+
+Two things worth flagging for review, both found while writing this:
+
+  * The precondition is asserted as sgen_is_world_stopped (), NOT as "a
+    collection is in progress". sgen clears
+    sgen_current_collection_generation at the end of the minor/major
+    collection function, which runs BEFORE sgen_restart_world, so at the
+    pre-start-world point the generation already reads -1 just as it does
+    outside a collection. An earlier draft asserted != -1 and would have
+    aborted the runtime on the first armed collection.
+  * Taking alcs_lock inside a GC pause would be a real hazard on a
+    threads-enabled runtime, where mono_coop_mutex_lock does a
+    MONO_ENTER_GC_SAFE transition when contended. It is sound here only
+    because this surface is DISABLE_THREADS-only and every MonoCoopMutex
+    operation is an empty inline there. The reasoning is recorded at the
+    call site rather than left implicit.
+
+Temporary diagnostic scaffolding on the same terms and the same tracking
+issue (#176) as the snapshot it complements: it retires when the residual
+root is found and fixed, or when the stop-rule fires.
+
+NOT COMPILE-VERIFIED LOCALLY. This was authored against the pinned commit
+with the series applied, but building the WASM runtime is not something the
+author can do on this machine; the runtime CI on this PR is the first real
+compile. Reviewers should treat a green CI as the first evidence it builds,
+and the behaviour claims above as unexercised until someone runs a flagged
+session with the scan armed.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+---
+ .../mono/metadata/assembly-load-context.c     | 209 +++++++++++++++++-
+ src/mono/mono/metadata/gc-internals.h         |  91 ++++++++
+ src/mono/mono/metadata/loader-internals.h     |  15 ++
+ src/mono/mono/metadata/sgen-mono.c            | 153 +++++++++++++
+ src/mono/mono/metadata/sgen-stw.c             |  16 ++
+ 5 files changed, 483 insertions(+), 1 deletion(-)
+
+diff --git a/src/mono/mono/metadata/assembly-load-context.c b/src/mono/mono/metadata/assembly-load-context.c
+index 1054345..a2abd44 100644
+--- a/src/mono/mono/metadata/assembly-load-context.c
++++ b/src/mono/mono/metadata/assembly-load-context.c
+@@ -515,6 +515,207 @@ alc_condemned_snapshot_fill (gint32 *fields, gint32 length, gint32 slot_budget)
+ 	return ALC_SNAPSHOT_FIELD_COUNT;
+ }
+ 
++/*
++ * ===========================================================================================
++ * Referrer lookup for condemned collectible contexts (WHO holds the witness)
++ * ===========================================================================================
++ *
++ * THE SINGLE SOURCE for this surface's contract, as its sibling block above is for the
++ * condemned-set snapshot. gc-internals.h and sgen-mono.c point here.
++ *
++ * REMOVAL. Temporary diagnostic scaffolding, on exactly the same terms and the same tracking
++ * issue as the snapshot.
++ * TODO(unoplatform/Uno.DotnetRuntime.WebAssembly#176): remove this block,
++ * mono_alc_referrer_scan_at_gc_pause, its call site in sgen_client_restart_world and
++ * sgen_scan_referrers_of_condemned once EITHER (a) the residual root is identified and fixed,
++ * or (b) the stop-rule fires.
++ *
++ * WHY THIS EXISTS AND THE SNAPSHOT DOES NOT SUFFICE. The snapshot answered its question in the
++ * negative. Across eight complete unsaturated sweeps of a stranding repro, every handle bucket
++ * read 0 -- strong, pinned and weak-track alike -- while managers_in_scope equalled
++ * live_witnesses exactly on every cycle and never decayed. That rules out a GC handle DIRECTLY
++ * targeting a condemned object, which is all the snapshot can ever see: its attribution is ONE
++ * HOP, so a handle on a container that merely references a witness is invisible to it. The
++ * witnesses are nevertheless reachable, so the reference runs through the object graph -- and no
++ * amount of further handle classification can follow a graph.
++ *
++ * WHAT THIS MEASURES. One bounded pass over the heap with the world already stopped, reporting
++ * for each condemned witness the CLASS of the objects that reference it, plus the field offset
++ * of the reference. That is the reverse of the snapshot's question, and it names the holder
++ * directly instead of narrowing the search space.
++ *
++ * WHEN IT RUNS -- and why it is not synchronous. The interesting moment is a REFUSAL: the
++ * quiescence gate answering not-quiescent is the only evidence that a witness is still held.
++ * But that gate runs from an icall with the world RUNNING, and a heap walk is only legal with
++ * the world stopped and the collection finished (mono_gc_walk_heap's own contract). So a
++ * refusal RECORDS A REQUEST and the next collection's pre-start-world point SERVES it. The
++ * consequence is worth stating plainly: the report is not attributable to one specific refusal,
++ * and if the process never collects again after a refusal, no report is ever produced. In the
++ * host that motivated this, the drain loop collects between attempts, so a request is served
++ * within one collection.
++ *
++ * A request is a single flag, not a queue: while one is outstanding, further refusals coalesce
++ * into it. The alternative -- one report per refusal -- would emit the same referrer shape once
++ * per retry in a loop that retries by design.
++ *
++ * DOUBLE OPT-IN. MONO_WASM_ENABLE_ALC_UNLOAD alone does NOT arm this. It also needs
++ * MONO_WASM_ALC_UNLOAD_REFERRER_SCAN, because unlike the snapshot -- a read-only gauge a caller
++ * chooses to poll -- this adds work to a collection pause that nothing asked for. A flagged
++ * session that has not asked for referrers must pay nothing.
++ *
++ * HOW TO SEE THE OUTPUT, and why silence is ambiguous. The report goes to the runtime's own
++ * assembly trace (mono_trace / MONO_TRACE_ASSEMBLY at INFO), so it also needs the assembly
++ * trace mask enabled: --trace=asm at a level of info or finer, i.e. monoTraceMask=asm and
++ * monoTraceLevel=info in a browser host. WITHOUT THAT MASK THE SCAN STILL RUNS AND SAYS
++ * NOTHING, which is indistinguishable from "no referrers found". An empty console is therefore
++ * never evidence; the saturated and objects_scanned/objects_visited figures in the report are
++ * the only things that qualify a negative result.
++ *
++ * WHAT A RESULT PROVES. A referrer row is direct evidence: that object, of that class, holds a
++ * reference to that witness at that offset. An EMPTY report is much weaker and means anything
++ * only when the scan did not saturate -- see object_budget on MonoSgenCondemnedReferrerScan,
++ * where the budget bounds the reference scanning but not the object enumeration. A saturated
++ * scan that finds nothing is inconclusive, exactly as a saturated snapshot is.
++ */
++
++/* Set by a refusal, consumed by the next collection pause. Coalescing, not a queue (see the
++ * block above). */
++static gboolean alc_referrer_scan_requested;
++
++/* Objects whose reference fields the pause-time walk may examine. Sized so the walk costs a
++ * bounded slice of a pause on the heaps this diagnostic runs against, in the same spirit as
++ * ALC_CONDEMNED_HANDLE_SLOT_BUDGET: large enough to cover a stranding repro's heap, small
++ * enough that saturation gets reported rather than silently paid for. */
++#define ALC_REFERRER_SCAN_OBJECT_BUDGET 400000
++
++/* Explicit, separate opt-in on top of MONO_WASM_ENABLE_ALC_UNLOAD (see DOUBLE OPT-IN above).
++ * Read once: an env lookup must not be repeated inside a GC pause. */
++static gboolean
++alc_referrer_scan_enabled (void)
++{
++	static int enabled = -1;
++	if (enabled == -1) {
++		char *val = g_getenv ("MONO_WASM_ALC_UNLOAD_REFERRER_SCAN");
++		enabled = (val && (!g_ascii_strcasecmp (val, "1") || !g_ascii_strcasecmp (val, "true"))) ? 1 : 0;
++		g_free (val);
++	}
++	return enabled != 0;
++}
++
++/* Called on a quiescence refusal. Cheap and allocation-free: the work happens at the pause. */
++static void
++alc_referrer_scan_request (void)
++{
++	if (alc_referrer_scan_enabled ())
++		alc_referrer_scan_requested = TRUE;
++}
++
++static gboolean
++alc_referrer_object_set_visit (MonoMemoryManager *mm, gpointer user_data)
++{
++	GHashTable *objects = (GHashTable *)user_data;
++
++	MonoObject *witness = alc_manager_witness_object (mm);
++	if (witness)
++		g_hash_table_insert (objects, witness, witness);
++	return TRUE;
++}
++
++/*
++ * Serve an outstanding request. Runs from sgen_client_restart_world with the world STOPPED and
++ * the collection finished, which is the only point a heap walk is legal.
++ *
++ * The condemned object set is rebuilt HERE, inside the pause, and never carried in from the
++ * refusal that requested the scan: a moving collector relocates objects, so a set captured
++ * earlier would hold stale pointers. The manager and context structs are native and stable, so
++ * re-deriving the set from the ALC list is the sound way to do it.
++ *
++ * LOCKING, and why taking a lock inside a GC pause is sound HERE and would not be in general.
++ * This takes alcs_lock and, under it, a context's memory-managers lock via
++ * alc_foreach_teardown_manager -- the same single nesting direction the snapshot uses. On a
++ * threads-enabled runtime that would be a hazard worth refusing: mono_coop_mutex_lock does a
++ * MONO_ENTER_GC_SAFE thread-state transition when contended, which is not something to do from
++ * inside a collection pause. This surface is compiled out there. On the DISABLE_THREADS build it
++ * is the only one that exists, every MonoCoopMutex operation is an EMPTY INLINE (see the
++ * DISABLE_THREADS branch of mono-coop-mutex.h), so both locks compile to nothing:
++ * no acquisition, no state transition, and no deadlock to reason about. The calls are kept
++ * rather than elided so this code reads like every other traversal of the ALC list, and so it
++ * stays correct if the surface is ever built with threads enabled -- at which point the
++ * transition above becomes a real question again.
++ */
++void
++mono_alc_referrer_scan_at_gc_pause (void)
++{
++	if (!alc_referrer_scan_requested)
++		return;
++
++	/* Clear FIRST: a scan that finds nothing has still served the request, and re-arming on
++	 * failure would attach the cost to every subsequent collection. */
++	alc_referrer_scan_requested = FALSE;
++
++#ifdef HAVE_SGEN_GC
++	GHashTable *objects = g_hash_table_new (g_direct_hash, g_direct_equal);
++
++	alcs_lock ();
++	for (GSList *tmp = alcs; tmp; tmp = tmp->next) {
++		MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)tmp->data;
++		if (!alc_is_condemned (alc))
++			continue;
++
++		/* The same two identity sources the snapshot uses: the managed wrapper (promoted to a
++		 * strong handle while an unload is in flight) and each manager's witness. */
++		if (alc->gchandle) {
++			MonoObject *wrapper = (MonoObject *)mono_gchandle_get_target_internal (alc->gchandle);
++			if (wrapper)
++				g_hash_table_insert (objects, wrapper, wrapper);
++		}
++
++		alc_foreach_teardown_manager (alc, alc_referrer_object_set_visit, objects);
++	}
++	alcs_unlock ();
++
++	if (g_hash_table_size (objects) == 0) {
++		/* Requested while stranded, served after the strand cleared. Reported rather than
++		 * dropped: it separates "nothing holds the witness" from "the scan never ran". */
++		mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY,
++			"[alc-referrers] no condemned objects at pause; request served with nothing to search for");
++		g_hash_table_destroy (objects);
++		return;
++	}
++
++	MonoSgenCondemnedReferrerScan scan;
++	memset (&scan, 0, sizeof (scan));
++	scan.condemned_objects = objects;
++	scan.object_budget = ALC_REFERRER_SCAN_OBJECT_BUDGET;
++	sgen_scan_referrers_of_condemned (&scan);
++
++	/* One summary line, then one line per described referrer. The summary carries the figures
++	 * that qualify the rows -- and that qualify their ABSENCE, which is the reading mistake
++	 * this diagnostic is most likely to invite. */
++	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY,
++		"[alc-referrers] witnesses=%u referenced=%d edges=%d described=%d objects=%d/%d saturated=%d",
++		g_hash_table_size (objects), scan.witnesses_referenced, scan.referrer_edges,
++		scan.referrers_recorded, scan.objects_scanned, scan.objects_visited,
++		scan.saturated ? 1 : 0);
++
++	for (gint32 i = 0; i < scan.referrers_recorded; ++i) {
++		MonoSgenCondemnedReferrer *row = &scan.referrers [i];
++		mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY,
++			"[alc-referrers]   witness=%p <- %s.%s[%p] +%u",
++			row->witness,
++			row->referrer_klass_namespace ? row->referrer_klass_namespace : "?",
++			row->referrer_klass_name ? row->referrer_klass_name : "?",
++			row->referrer, row->field_offset);
++	}
++
++	g_hash_table_destroy (objects);
++#else
++	/* No sgen: no heap walk exists. Say so, rather than letting silence read as "no referrers". */
++	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY,
++		"[alc-referrers] unavailable: no sgen heap walk in this build");
++#endif
++}
++
+ static void
+ retired_scout_targets_add (MonoMemoryManager *memory_manager)
+ {
+@@ -953,8 +1154,14 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
+ 	if (!alc->unloading)
+ 		return FORCE_UNLOAD_REJECTED;
+ 
+-	if (!alc_is_managed_quiescent (alc))
++	if (!alc_is_managed_quiescent (alc)) {
++		/* A refusal is the only evidence that a witness is still held, so it is the trigger for
++		 * the referrer lookup -- served at the next collection pause, because a heap walk needs
++		 * the world stopped. No-op unless MONO_WASM_ALC_UNLOAD_REFERRER_SCAN is set; see the
++		 * "Referrer lookup for condemned collectible contexts" block. */
++		alc_referrer_scan_request ();
+ 		return FORCE_UNLOAD_NOT_QUIESCENT;
++	}
+ 
+ 	mono_alc_free (alc);
+ 	return FORCE_UNLOAD_COMPLETED;
+diff --git a/src/mono/mono/metadata/gc-internals.h b/src/mono/mono/metadata/gc-internals.h
+index 1c51c11..b9f99a2 100644
+--- a/src/mono/mono/metadata/gc-internals.h
++++ b/src/mono/mono/metadata/gc-internals.h
+@@ -490,6 +490,97 @@ typedef struct {
+ } MonoSgenCondemnedHandleScan;
+ 
+ void sgen_scan_handles_into_managers (MonoSgenCondemnedHandleScan *scan);
++
++/*
++ * Reverse lookup: WHICH OBJECTS REFERENCE a condemned LoaderAllocator witness. Implemented in
++ * sgen-mono.c; the canonical rationale and the reporting contract live with the sole consumer,
++ * in the "Referrer lookup for condemned collectible contexts" block of
++ * assembly-load-context.c.
++ *
++ * This is the complement of sgen_scan_handles_into_managers above, and it exists because that
++ * scan answered its question in the negative: across repeated stranding cycles every handle
++ * bucket reads 0 while live witnesses persist, which rules out a GC handle DIRECTLY targeting a
++ * condemned object and leaves the object graph. Handle classification is ONE HOP by
++ * construction and cannot follow that graph; this walk starts from the heap instead and reports
++ * the referrers themselves.
++ *
++ * PRECONDITION, and the reason this one differs from its sibling: the heap walk is only legal
++ * with the world already STOPPED and the collection finished, i.e. from the
++ * MONO_GC_EVENT_PRE_START_WORLD point (see mono_gc_walk_heap's own contract in sgen-mono.c),
++ * and it asserts sgen_is_world_stopped (). The handle scan runs with the world RUNNING instead,
++ * from an ordinary icall, because it only reads handle slots and must not be able to observe a
++ * collector mid-rewrite. Note that BOTH points see sgen_current_collection_generation == -1 --
++ * sgen clears it before restarting the world -- so the generation cannot tell them apart and
++ * neither assertion is phrased in terms of it.
++ */
++
++/* Referrers described per witness before further hits on that witness are counted but not
++ * described. Small on purpose: the question is "what CLASS of thing holds this", and the first
++ * few answers settle it -- an unbounded list would turn a diagnostic into a heap dump. */
++#define MONO_SGEN_CONDEMNED_REFERRERS_PER_WITNESS 4
++/* Distinct witnesses described per scan. A stranding repro accumulates one witness per cycle
++ * and the referrer SHAPE repeats, so describing the first few is what identifies the holder. */
++#define MONO_SGEN_CONDEMNED_WITNESSES_REPORTED 8
++
++typedef struct {
++	/* The referenced (condemned) object this row is about, and the referrer that points at it.
++	 * Raw pointers, valid only until the world restarts -- printed by the consumer inside the
++	 * same pause and never retained. */
++	gpointer witness;
++	gpointer referrer;
++	/* The referrer's class, which is the actual answer being sought. NULL-safe: a referrer whose
++	 * vtable or class cannot be read is recorded with NULL names rather than dereferenced. */
++	const char *referrer_klass_name;
++	const char *referrer_klass_namespace;
++	/* Byte offset of the referencing field within the referrer, as reported by the object
++	 * scanner. Cheap to carry, and it separates "a field of X" from "an element of X". */
++	guint32 field_offset;
++} MonoSgenCondemnedReferrer;
++
++typedef struct {
++	/* IN: set of MonoObject* identities to find the referrers OF -- the condemned contexts'
++	 * LoaderAllocator witnesses and managed wrapper objects. MUST be built by the consumer
++	 * inside the same pause: a set built earlier cannot be carried across a collection, because
++	 * a moving collector relocates its members. */
++	GHashTable *condemned_objects;
++	/* IN: cap on objects whose REFERENCE FIELDS are examined. MUST be > 0 (asserted).
++	 *
++	 * READ THIS BEFORE TRUSTING AN EMPTY RESULT. The cap bounds the per-object REFERENCE SCAN
++	 * and NOT the object enumeration, because sgen's heap iterators (sgen_scan_area_with_callback,
++	 * the major collector's iterate_objects, sgen_los_iterate_objects) run to completion and
++	 * their callbacks cannot stop them. So a scan costs a full enumeration of the heap -- which
++	 * includes forcing the major collector to finish sweeping, since the walk passes
++	 * ITERATE_OBJECTS_SWEEP_ALL exactly as mono_gc_walk_heap does, and that is NOT free on a
++	 * lazily-swept heap -- plus at most `object_budget` reference scans on top. The budget bounds
++	 * the second half only; it is not a bound on the whole operation and must not be read as one.
++	 * Once it is spent, later objects are COUNTED but not examined, `saturated` is set, and every
++	 * count below becomes a LOWER BOUND: an empty referrer list from a saturated scan says
++	 * nothing at all. */
++	gint32 object_budget;
++
++	/* OUT: referrer rows, filled in discovery order up to the caps above. */
++	MonoSgenCondemnedReferrer referrers [MONO_SGEN_CONDEMNED_WITNESSES_REPORTED * MONO_SGEN_CONDEMNED_REFERRERS_PER_WITNESS];
++	/* OUT: rows actually filled in `referrers`. */
++	gint32 referrers_recorded;
++	/* OUT: total referencing EDGES found into condemned_objects, including those not described
++	 * because a per-witness or per-scan cap was already reached. referrers_recorded <
++	 * referrer_edges is a DESCRIPTION cap, not truncation of the search -- distinct from
++	 * `saturated`, which reports the search itself being cut short. */
++	gint32 referrer_edges;
++	/* OUT: distinct condemned objects found to have at least one referrer. */
++	gint32 witnesses_referenced;
++	/* OUT: objects the heap iterators presented. This is the TRUE total, not an estimate: the
++	 * iterators always run to completion (see object_budget), so no denominator is fabricated. */
++	gint32 objects_visited;
++	/* OUT: objects whose reference fields were actually examined, i.e. the part of
++	 * objects_visited the budget paid for. */
++	gint32 objects_scanned;
++	/* OUT: TRUE when objects_scanned < objects_visited, i.e. the budget ran out and the search
++	 * is incomplete (see object_budget). */
++	gboolean saturated;
++} MonoSgenCondemnedReferrerScan;
++
++void sgen_scan_referrers_of_condemned (MonoSgenCondemnedReferrerScan *scan);
+ #endif
+ 
+ #endif /* __MONO_METADATA_GC_INTERNAL_H__ */
+diff --git a/src/mono/mono/metadata/loader-internals.h b/src/mono/mono/metadata/loader-internals.h
+index 4275a39..4a3191e 100644
+--- a/src/mono/mono/metadata/loader-internals.h
++++ b/src/mono/mono/metadata/loader-internals.h
+@@ -291,6 +291,21 @@ mono_alc_get_all_loaded_assemblies (void);
+ GPtrArray*
+ mono_alc_get_all (void);
+ 
++#ifdef DISABLE_THREADS
++/*
++ * Serve an outstanding condemned-referrer scan request. MUST be called with the world STOPPED
++ * and the collection finished (the MONO_GC_EVENT_PRE_START_WORLD point), which is the only
++ * place a heap walk is legal; sgen_client_restart_world is the sole caller. A no-op unless a
++ * quiescence refusal requested a scan AND MONO_WASM_ALC_UNLOAD_REFERRER_SCAN is set.
++ *
++ * Diagnostic scaffolding for the host-triggered collectible-ALC unload work. The contract lives
++ * in the "Referrer lookup for condemned collectible contexts" block of assembly-load-context.c,
++ * which also names the tracking issue for removing it.
++ */
++void
++mono_alc_referrer_scan_at_gc_pause (void);
++#endif
++
+ MonoMemoryManager *
+ mono_mem_manager_new (MonoAssemblyLoadContext **alcs, int nalcs, gboolean collectible);
+ 
+diff --git a/src/mono/mono/metadata/sgen-mono.c b/src/mono/mono/metadata/sgen-mono.c
+index fd4e6e5..7ed2fee 100644
+--- a/src/mono/mono/metadata/sgen-mono.c
++++ b/src/mono/mono/metadata/sgen-mono.c
+@@ -2064,6 +2064,159 @@ sgen_scan_handles_into_managers (MonoSgenCondemnedHandleScan *scan)
+ 
+ 	sgen_condemned_scan_in_progress = FALSE;
+ }
++
++/*
++ * Referrer lookup for the same diagnostics: given a set of condemned objects, report WHICH
++ * OBJECTS IN THE HEAP REFERENCE THEM. The canonical rationale and the reporting contract live
++ * with the sole consumer, in the "Referrer lookup for condemned collectible contexts" block of
++ * assembly-load-context.c; the field-level contract is on MonoSgenCondemnedReferrerScan in
++ * gc-internals.h. This file only implements the walk.
++ *
++ * PRECONDITION: the world is STOPPED and the collection has finished, i.e. this runs from the
++ * MONO_GC_EVENT_PRE_START_WORLD point. That is mono_gc_walk_heap's documented contract and it
++ * applies here for the same reasons: the nursery fragments must be cleared, the major heap must
++ * be in a sweepable state, and no mutator may be writing references while they are read.
++ *
++ * WHY NOT mono_gc_walk_heap ITSELF. That entry point buffers up to REFS_SIZE references and
++ * calls a MonoGCReferences callback, with no budget and no way for the callback to stop the
++ * walk -- the same shape problem sgen_gchandle_foreach_slot_bounded was added to solve for the
++ * handle tables. Reusing it would mean paying the full per-object reference scan over the whole
++ * heap with no bound, and buffering every reference of every object when all this walk needs is
++ * a single hash lookup per reference. So the three iteration passes are mirrored here with a
++ * scanner that tests each reference in place and stops examining objects once its budget is
++ * spent. The passes themselves still run to completion, because sgen's iterators cannot be
++ * stopped -- which is exactly why objects_visited is a true total and objects_scanned is not.
++ */
++
++static MonoSgenCondemnedReferrerScan *sgen_referrer_scan_current;
++static gboolean sgen_referrer_scan_in_progress;
++
++/* Per-witness description budget. Keyed on the witness pointer, value is the number of rows
++ * already emitted for it, so the caps in gc-internals.h are enforced per witness rather than
++ * letting one heavily-referenced object consume every row. */
++static GHashTable *sgen_referrer_scan_described;
++
++static void
++sgen_referrer_record (GCObject *referrer, GCObject *witness, uintptr_t offset)
++{
++	MonoSgenCondemnedReferrerScan *scan = sgen_referrer_scan_current;
++
++	/* Every hit counts as an edge, described or not: the counts must stay honest even when the
++	 * description caps hide the individual rows. */
++	scan->referrer_edges++;
++
++	gpointer prior = g_hash_table_lookup (sgen_referrer_scan_described, witness);
++	guint described = prior ? GPOINTER_TO_UINT (prior) : 0;
++	if (described == 0)
++		scan->witnesses_referenced++;
++
++	if (described >= MONO_SGEN_CONDEMNED_REFERRERS_PER_WITNESS)
++		return;
++	if (scan->referrers_recorded >= (gint32)G_N_ELEMENTS (scan->referrers))
++		return;
++
++	MonoSgenCondemnedReferrer *row = &scan->referrers [scan->referrers_recorded++];
++	row->witness = witness;
++	row->referrer = referrer;
++	row->field_offset = (guint32)offset;
++
++	/* NULL-safe on purpose: a referrer whose vtable or class cannot be read is still worth
++	 * reporting as an edge, and this is a diagnostic that must not be able to abort the runtime
++	 * from inside a GC pause. */
++	MonoVTable *vtable = (MonoVTable *)SGEN_LOAD_VTABLE (referrer);
++	MonoClass *klass = vtable ? vtable->klass : NULL;
++	row->referrer_klass_name = klass ? m_class_get_name (klass) : NULL;
++	row->referrer_klass_namespace = klass ? m_class_get_name_space (klass) : NULL;
++
++	g_hash_table_insert (sgen_referrer_scan_described, witness, GUINT_TO_POINTER (described + 1));
++}
++
++#undef HANDLE_PTR
++#define HANDLE_PTR(ptr,obj)	do {			GCObject *__ref = *(ptr);			if (__ref && g_hash_table_contains (sgen_referrer_scan_current->condemned_objects, __ref))				sgen_referrer_record ((GCObject*)start, __ref, (char*)(ptr) - (char*)start);		} while (0)
++
++static void
++sgen_referrer_scan_object (GCObject *obj)
++{
++	char *start = (char*)obj;
++	SgenDescriptor desc = sgen_obj_get_descriptor (obj);
++
++#include "sgen/sgen-scan-object.h"
++}
++
++static void
++sgen_referrer_visit_object (GCObject *obj, size_t size, void *data)
++{
++	MonoSgenCondemnedReferrerScan *scan = (MonoSgenCondemnedReferrerScan *)data;
++
++	/* Counted unconditionally: the iterators run to completion whatever the budget does, so
++	 * this is the honest denominator the report needs. */
++	scan->objects_visited++;
++
++	if (scan->objects_scanned >= scan->object_budget) {
++		scan->saturated = TRUE;
++		return;
++	}
++
++	scan->objects_scanned++;
++	sgen_referrer_scan_object (obj);
++}
++
++void
++sgen_scan_referrers_of_condemned (MonoSgenCondemnedReferrerScan *scan)
++{
++	/* Internal API, but a NULL out-parameter must never be written through. */
++	if (!scan)
++		return;
++
++	memset (scan->referrers, 0, sizeof (scan->referrers));
++	scan->referrers_recorded = 0;
++	scan->referrer_edges = 0;
++	scan->witnesses_referenced = 0;
++	scan->objects_visited = 0;
++	scan->objects_scanned = 0;
++	scan->saturated = FALSE;
++
++	/* Nothing to find referrers of: skip the sweep entirely rather than walking the whole heap
++	 * to accumulate zeroes. Nothing was VISITED either, because no walk ran. */
++	if (!scan->condemned_objects || g_hash_table_size (scan->condemned_objects) == 0)
++		return;
++
++	/*
++	 * See PRECONDITION above. The check is sgen_is_world_stopped () and deliberately NOT
++	 * "a collection is in progress": sgen clears sgen_current_collection_generation at the end
++	 * of the minor/major collection function, which runs BEFORE sgen_restart_world, so at the
++	 * pre-start-world point the generation already reads -1 just as it does outside a
++	 * collection. World-stopped is the property this walk actually depends on.
++	 */
++	g_assert (sgen_is_world_stopped ());
++	g_assert (!sgen_referrer_scan_in_progress);
++
++	/* No unbounded mode, for the same reason the handle scan has none: a diagnostic that runs
++	 * inside a GC pause on the single browser thread must carry a bound by construction, so a
++	 * non-positive budget is a caller bug rather than a mode. */
++	g_assert (scan->object_budget > 0);
++
++	sgen_referrer_scan_in_progress = TRUE;
++	sgen_referrer_scan_current = scan;
++	sgen_referrer_scan_described = g_hash_table_new (g_direct_hash, g_direct_equal);
++
++	/*
++	 * The same three regions mono_gc_walk_heap covers, in the same order, because between them
++	 * they are the heap: the nursery, the major heap, and the large-object space. Missing one
++	 * would silently narrow the search and make an empty result untrustworthy in a way
++	 * `saturated` does not report.
++	 */
++	sgen_clear_nursery_fragments ();
++	sgen_scan_area_with_callback (sgen_nursery_section->data, sgen_nursery_section->end_data,
++			sgen_referrer_visit_object, scan, FALSE, TRUE);
++	sgen_major_collector.iterate_objects (ITERATE_OBJECTS_SWEEP_ALL, sgen_referrer_visit_object, scan);
++	sgen_los_iterate_objects (sgen_referrer_visit_object, scan);
++
++	g_hash_table_destroy (sgen_referrer_scan_described);
++	sgen_referrer_scan_described = NULL;
++	sgen_referrer_scan_current = NULL;
++	sgen_referrer_scan_in_progress = FALSE;
++}
+ #endif /* DISABLE_THREADS */
+ 
+ /*
+diff --git a/src/mono/mono/metadata/sgen-stw.c b/src/mono/mono/metadata/sgen-stw.c
+index daaafba..7818d1e 100644
+--- a/src/mono/mono/metadata/sgen-stw.c
++++ b/src/mono/mono/metadata/sgen-stw.c
+@@ -25,6 +25,7 @@
+ #include "sgen/sgen-client.h"
+ #include "metadata/sgen-bridge-internals.h"
+ #include "metadata/gc-internals.h"
++#include "metadata/loader-internals.h"
+ #include "utils/mono-threads.h"
+ #include "utils/mono-threads-debug.h"
+ #ifdef HOST_BROWSER
+@@ -195,6 +196,21 @@ sgen_client_restart_world (int generation, gboolean serial_collection, gint64 *s
+ 	if (MONO_PROFILER_ENABLED (gc_resize))
+ 		mono_sgen_gc_event_resize ();
+ 
++#ifdef DISABLE_THREADS
++	/*
++	 * Diagnostic scaffolding for the host-triggered collectible-ALC unload work: a quiescence
++	 * refusal cannot walk the heap itself (it runs with the world running), so it records a
++	 * request and this point -- world stopped, collection finished -- serves it. A no-op unless
++	 * a request is outstanding and MONO_WASM_ALC_UNLOAD_REFERRER_SCAN is set, so an ordinary
++	 * collection pays one load and a branch. See the "Referrer lookup for condemned collectible
++	 * contexts" block in assembly-load-context.c, which names the tracking issue for removal.
++	 *
++	 * Placed BEFORE the profiler event so it observes the same heap a PRE_START_WORLD handler
++	 * would, and cannot be reordered behind a handler that allocates.
++	 */
++	mono_alc_referrer_scan_at_gc_pause ();
++#endif
++
+ 	MONO_PROFILER_RAISE (gc_event, (MONO_GC_EVENT_PRE_START_WORLD, generation, serial_collection));
+ 
+ 	FOREACH_THREAD_ALL (info) {

--- a/patches/0015-report-referrers-of-condemned-collectible-alc-witnesses.patch
+++ b/patches/0015-report-referrers-of-condemned-collectible-alc-witnesses.patch
@@ -57,10 +57,26 @@ whenever the key is alive. On mono that is not a corner case: DependentHandle
 IS an Ephemeron[] ("Instead of dependent handles, mono uses arrays of
 Ephemeron objects"), so every CWT goes through it. A witness held only that
 way would have produced an unsaturated EMPTY report -- a false negative of
-exactly the kind this surface exists to rule out. A second pass walks
-ephemeron_list at the same suspended point, mirroring the collector's own
-liveness and tombstone tests so it reports the edges the collector actually
-traverses, and records the KEY as the referrer with the row marked dependent.
+exactly the kind this surface exists to rule out.
+
+The ephemeron pass runs FIRST and applies NO liveness predicate, both
+deliberately.
+
+No predicate, because one would be wrong here and is also unnecessary.
+sgen_client_clear_unreachable_ephemerons already ran inside the finishing
+collection: it unlinked and freed nodes whose array was dead and tombstoned
+every entry whose key was dead, clearing its value. The list is therefore
+already pruned to exactly the live arrays and live-keyed entries, and skipping
+NULL/tombstone keys is the whole test needed. An earlier revision mirrored the
+collector and called sgen_is_object_alive_for_current_gen, which silently
+dropped live PROMOTED entries: the major pass passes ITERATE_OBJECTS_SWEEP_ALL,
+marksweep's sweep_block clears block->mark_words, and with
+sgen_current_collection_generation already -1 that predicate falls through to
+sgen_major_is_object_alive and reads the cleared bit.
+
+First, because it shares the slot budget and running it last let a saturating
+heap walk starve it completely -- silently reinstating the blind spot it exists
+to close, in exactly the small-budget/large-heap case where it matters most.
 
 TWO BUDGETS, and neither bounds the pause. object_budget caps how many objects
 are ENTERED. reference_slot_budget caps the SET LOOKUPS, across every object
@@ -127,31 +143,49 @@ edge counts. Kind 13 is what makes the ephemeron blind spot testable at all.
 They are independent gauges, not a tuple: read kind 11 around 12/13 to know
 which scan they describe.
 
-Three regressions, all on the single-threaded flag-ON leg, which now sets
-MONO_WASM_ALC_UNLOAD_REFERRER_SCAN=1 -- the only leg that arms this code:
+FALSIFIABILITY. Three things were previously asserted only by comment, and are
+now testable:
 
-  * ForcedUnload_ReferrerScan_RefusalIsServedAtNextCollection -- a refusal plus
-    a collection advances kind 11 with the second opt-in set, and does NOT
-    without it, so the double opt-in is asserted in both directions.
-  * ForcedUnload_ReferrerScan_ReportsConditionalWeakTableDependentEdge -- a
-    live CWT key whose value is the condemned wrapper must produce a dependent
-    edge. Descriptor scanning structurally cannot see it, so this fails if the
-    ephemeron pass regresses.
-  * ForcedUnload_ReferrerScan_LargeReferenceArrayStillReports -- a 200k-element
-    reference array holding the wrapper must still report, which is where an
-    unbounded per-slot cost would surface.
+  * The slot budget is overridable DOWNWARD via
+    MONO_WASM_ALC_UNLOAD_REFERRER_SLOT_BUDGET, clamped to the production value
+    so an override can only ever shrink the walk. Without it saturation was
+    unreachable from a test -- a test heap cannot produce two million reference
+    slots -- so deleting the per-slot charge outright left every assertion
+    passing.
+  * Kinds 14 and 15 report the last scan's slot count and saturation flag, so
+    the cutoff can be asserted rather than inferred.
+  * Kinds 11-13 report scans reported, total edges and DEPENDENT edges, all as
+    edge counts taken from the scan itself rather than from the described rows,
+    so the description caps can never make a found edge read as absent.
 
-Each asserts the refusal itself rather than tolerating a Completed, since a
-Completed would make the rest vacuous, and each then drives its context
-TERMINAL. That last part is not tidiness: this suite has a standing invariant
-that every test leaves no context pending -- stated in
-Unload_DroppedRootsWithoutAnyForcedAttempt's own comment and asserted through
-PendingUnloadsGauge -- and a first revision of these three sustained their
-refusals past the end of the test, which failed two OTHER tests. The refusal
-half of each now lives in its own non-inlined frame so the rooting probe (and
-the CWT, and the wide array) are unreachable before the teardown runs, which a
-local in the test's frame would not reliably be: the interpreter scans its live
-slot region conservatively.
+Four legs, and each covers something the others cannot:
+
+  * ST flag OFF -- feature inactive.
+  * ST flag ON + scan armed + lowered slot budget -- the only leg that executes
+    this code. Asserts kind 11 advances after a refusal, that a CWT dependent
+    edge onto the condemned wrapper is reported (with the table, key and array
+    PROMOTED first, which is the configuration the invalid liveness predicate
+    dropped), and that a reference array sized from the lowered budget crosses
+    the cutoff exactly at it.
+  * ST flag ON + scan OFF -- new. The feature is active so refusals are real,
+    and the scan must still do nothing. Nothing asserted this before: flag OFF
+    cannot (no refusal is possible) and MT cannot (the surface is compiled
+    out), so deleting the second opt-in -- making every flagged session pay for
+    a heap walk in every pause -- would have stayed green everywhere.
+  * MT -- the surface is compiled out and rejection is proved.
+
+The loader sentinel gained a scan dimension that REQUIRES all three referrer
+tests present and passed on both ST feature-ON legs. It previously returned OK
+with all three names absent, so deleting them was a silent no-op.
+
+Each test drives its context TERMINAL afterwards. That is not tidiness: this
+suite has a standing invariant that no test leaves a context pending -- stated
+in Unload_DroppedRootsWithoutAnyForcedAttempt's own comment and asserted
+through PendingUnloadsGauge -- and a first revision sustained its refusals past
+the end of the test, failing two OTHER tests. The refusal half of each now
+lives in its own non-inlined frame so the probe, the CWT and the wide array are
+unreachable before teardown, which a local in the test's frame would not
+reliably be given the interpreter scans its live slot region conservatively.
 
 Temporary diagnostic scaffolding on the same terms and the same tracking
 issue (#176) as the snapshot it complements: it retires when the residual
@@ -159,19 +193,19 @@ root is found and fixed, or when the stop-rule fires.
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
 ---
- .../tests/ForcedNativeUnloadTests.cs          | 232 ++++++++++++++
- .../mono/metadata/assembly-load-context.c     | 292 ++++++++++++++++-
- src/mono/mono/metadata/gc-internals.h         | 143 +++++++++
+ .../tests/ForcedNativeUnloadTests.cs          | 296 +++++++++++++++
+ .../mono/metadata/assembly-load-context.c     | 343 +++++++++++++++++-
+ src/mono/mono/metadata/gc-internals.h         | 148 ++++++++
  src/mono/mono/metadata/loader-internals.h     |  15 +
- src/mono/mono/metadata/sgen-mono.c            | 293 ++++++++++++++++++
+ src/mono/mono/metadata/sgen-mono.c            | 306 ++++++++++++++++
  src/mono/mono/metadata/sgen-stw.c             |  16 +
- 6 files changed, 989 insertions(+), 2 deletions(-)
+ 6 files changed, 1122 insertions(+), 2 deletions(-)
 
 diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
-index 2b2f170..b51d33a 100644
+index 2b2f170..0bb1a45 100644
 --- a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 +++ b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
-@@ -178,6 +178,14 @@ private static bool FlagEnabled
+@@ -178,6 +178,28 @@ private static bool FlagEnabled
          private static bool GcHookRequested =>
              Environment.GetEnvironmentVariable("MONO_WASM_ALC_UNLOAD_TEST_GC_HOOK") == "1";
  
@@ -183,10 +217,24 @@ index 2b2f170..b51d33a 100644
 +        private static bool ReferrerScanRequested =>
 +            Environment.GetEnvironmentVariable("MONO_WASM_ALC_UNLOAD_REFERRER_SCAN") == "1";
 +
++        // Set by the armed CI leg to LOWER the referrer scan's reference-slot budget (the runtime
++        // clamps it to the production value, so it can only ever shrink). Without it, saturation is
++        // unreachable from a test -- a test heap cannot produce two million reference slots -- so
++        // deleting the per-slot charge outright would leave every assertion passing. Parsed rather
++        // than compared to "1" because the value is the budget.
++        private static int ReferrerScanSlotBudget
++        {
++            get
++            {
++                string value = Environment.GetEnvironmentVariable("MONO_WASM_ALC_UNLOAD_REFERRER_SLOT_BUDGET");
++                return int.TryParse(value, out int budget) && budget > 0 ? budget : 0;
++            }
++        }
++
          // Returns true (and the caller should no-op) only on a genuinely unpatched runtime. When CI
          // asserts the bridge must exist, a missing member fails loudly instead of self-skipping and
          // masking the regression.
-@@ -240,6 +248,17 @@ private static void GcQuiesce()
+@@ -240,6 +262,17 @@ private static void GcQuiesce()
          // Each NotQuiescent attempt must leave the once-only latch clear so a later attempt can
          // still Complete — i.e. the single retry is never consumed by a premature force.
          [MethodImpl(MethodImplOptions.NoInlining)]
@@ -204,7 +252,7 @@ index 2b2f170..b51d33a 100644
          private static async Task<int> ForceUntilCompletedAsync(AssemblyLoadContext context, int maxAttempts)
          {
              int outcome = NotQuiescent;
-@@ -1585,6 +1604,219 @@ public async Task ForcedUnload_RootedPointerFreeObjects_BlockNativeFree()
+@@ -1585,6 +1618,269 @@ public async Task ForcedUnload_RootedPointerFreeObjects_BlockNativeFree()
              await RunConservativelyPinnedLosWitnessProtocol();
          }
  
@@ -304,13 +352,22 @@ index 2b2f170..b51d33a 100644
 +                return;
 +            }
 +
-+            if (!ProtocolActive || !ReferrerScanRequested)
++            if (!ProtocolActive)
 +            {
 +                return;
 +            }
 +
 +            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
 +            (int scansBefore, int scansAfter, int dependentEdges, int totalEdges) = RefuseWithDependentEdge(context);
++
++            if (!ReferrerScanRequested)
++            {
++                // Feature on, scan opt-in absent: the second gate must actually gate. Asserted
++                // rather than skipped, so deleting that opt-in cannot stay green.
++                Assert.Equal(scansBefore, scansAfter);
++                await DriveTerminalAsync(context);
++                return;
++            }
 +
 +            Assert.True(scansAfter > scansBefore,
 +                $"no referrer scan was reported (kind 11 was {scansBefore}, now {scansAfter}), so the dependent-edge figures below would describe a different scan.");
@@ -336,6 +393,13 @@ index 2b2f170..b51d33a 100644
 +            var key = new object();
 +            var table = new ConditionalWeakTable<object, object>();
 +            table.Add(key, context);
++
++            // PROMOTE the table, the key and the ephemeron array out of the nursery before the
++            // armed collection. This is the configuration that regressed: an earlier revision
++            // applied the collector's liveness predicate inside the ephemeron pass, and after
++            // ITERATE_OBJECTS_SWEEP_ALL cleared the major mark bits it read every promoted entry
++            // as dead and skipped it. Nursery-only entries would not have caught that.
++            GcQuiesce();
 +
 +            int scansBefore = ScoutStats(11);
 +            Assert.Equal(NotQuiescent, Force(context));
@@ -372,19 +436,51 @@ index 2b2f170..b51d33a 100644
 +                return;
 +            }
 +
-+            if (!ProtocolActive || !ReferrerScanRequested)
++            if (!ProtocolActive)
 +            {
 +                return;
 +            }
 +
++            int budget = ReferrerScanSlotBudget;
 +            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
-+            (int scansBefore, int scansAfter, int totalEdges) = RefuseWithWideReferenceArray(context);
++
++            // Enough non-null elements to cross a lowered budget several times over. Sized from the
++            // budget itself rather than hard-coded, so the test cannot silently stop crossing it if
++            // the leg's value changes.
++            int elements = budget > 0 ? Math.Min(budget * 4, 2_000_000) : 200_000;
++            (int scansBefore, int scansAfter, int totalEdges, int slotsVisited, int saturated) =
++                RefuseWithWideReferenceArray(context, elements);
++
++            if (!ReferrerScanRequested)
++            {
++                Assert.Equal(scansBefore, scansAfter);
++                await DriveTerminalAsync(context);
++                return;
++            }
 +
 +            Assert.True(scansAfter > scansBefore,
 +                $"the scan did not report with a large reference array live: kind 11 was {scansBefore}, now {scansAfter}. An unbounded per-slot cost would surface here as a hang or an abort rather than a missing report, so this failing at all is worth reading carefully.");
 +
-+            Assert.True(totalEdges > 0,
-+                $"kind 12 (edges) is {totalEdges}: the array holding the condemned wrapper produced no edge, so either the slot budget cut the walk short before reaching it or the element was not scanned.");
++            if (budget > 0)
++            {
++                // THE POINT OF THIS TEST. With the budget lowered below the array's element count,
++                // the charge must actually cut the walk off: slots looked up must stop AT the
++                // budget and saturation must be reported. Delete sgen_referrer_charge_slot and
++                // both of these fail, which the earlier version of this test could not detect --
++                // 200k elements never approached the 2,000,000 production budget, so guarded and
++                // unguarded code behaved identically.
++                Assert.Equal(1, saturated);
++                Assert.Equal(budget, slotsVisited);
++            }
++            else
++            {
++                // No lowered budget on this leg: the cutoff is unreachable, so only report that
++                // the walk completed. Explicitly NOT asserting saturation here -- with the
++                // production budget it would be asserting the constant's value.
++                Assert.Equal(0, saturated);
++                Assert.True(totalEdges > 0,
++                    $"kind 12 (edges) is {totalEdges}: the array holding the condemned wrapper produced no edge, so the element was not scanned.");
++            }
 +
 +            await DriveTerminalAsync(context);
 +        }
@@ -393,14 +489,14 @@ index 2b2f170..b51d33a 100644
 +        // it roots the witness and must be unreachable before the caller drives the context
 +        // terminal.
 +        [MethodImpl(MethodImplOptions.NoInlining)]
-+        private static (int ScansBefore, int ScansAfter, int TotalEdges) RefuseWithWideReferenceArray(
-+            AssemblyLoadContext context)
++        private static (int ScansBefore, int ScansAfter, int TotalEdges, int SlotsVisited, int Saturated)
++            RefuseWithWideReferenceArray(AssemblyLoadContext context, int elements)
 +        {
 +            object[] rooted = LoadUnloadReturningRootedPointerFreeProbe(context, losArray: true, new WeakReference[1]);
 +
 +            // Every element non-null, so every element costs a slot charge. The last points at the
 +            // condemned wrapper, making the array a genuine referrer the walk cannot skip.
-+            object[] wide = new object[200_000];
++            object[] wide = new object[elements];
 +            object filler = new object();
 +            for (int i = 0; i < wide.Length; i++)
 +            {
@@ -414,21 +510,23 @@ index 2b2f170..b51d33a 100644
 +
 +            int scansAfter = ScoutStats(11);
 +            int totalEdges = ScoutStats(12);
++            int slotsVisited = ScoutStats(14);
++            int saturated = ScoutStats(15);
 +
 +            GC.KeepAlive(rooted);
 +            GC.KeepAlive(wide);
 +            GC.KeepAlive(filler);
-+            return (scansBefore, scansAfter, totalEdges);
++            return (scansBefore, scansAfter, totalEdges, slotsVisited, saturated);
 +        }
 +
          [Fact]
          public async Task ForceNativeUnload_AfterCompleted_ManagedLoadApisReject()
          {
 diff --git a/src/mono/mono/metadata/assembly-load-context.c b/src/mono/mono/metadata/assembly-load-context.c
-index 1054345..99895f5 100644
+index 1054345..bda279b 100644
 --- a/src/mono/mono/metadata/assembly-load-context.c
 +++ b/src/mono/mono/metadata/assembly-load-context.c
-@@ -515,6 +515,265 @@ alc_condemned_snapshot_fill (gint32 *fields, gint32 length, gint32 slot_budget)
+@@ -515,6 +515,306 @@ alc_condemned_snapshot_fill (gint32 *fields, gint32 length, gint32 slot_budget)
  	return ALC_SNAPSHOT_FIELD_COUNT;
  }
  
@@ -527,6 +625,14 @@ index 1054345..99895f5 100644
 +static gint32 alc_referrer_last_edges;
 +static gint32 alc_referrer_last_dependent_edges;
 +
++/* Reference slots looked up by the most recently reported scan, and whether that scan SATURATED.
++ * Kinds 14 and 15. Without these the slot budget could only be asserted by reading the source:
++ * a test heap cannot reach the production budget, so nothing could tell a working charge from a
++ * deleted one. With a lowered budget (see alc_referrer_scan_slot_budget) a test can cross the
++ * cutoff deliberately and assert that it was crossed. */
++static gint32 alc_referrer_last_slots_visited;
++static gint32 alc_referrer_last_saturated;
++
 +/* Objects the pause-time walk may ENTER for reference scanning. Large enough to cover a
 + * stranding repro's heap, small enough that saturation is reported rather than silently paid
 + * for. */
@@ -542,6 +648,37 @@ index 1054345..99895f5 100644
 + * precisely what each budget does and does not cover -- an earlier revision of this comment
 + * claimed a "bounded slice of a pause", which was not true of either budget. */
 +#define ALC_REFERRER_SCAN_SLOT_BUDGET 2000000
++
++/*
++ * Test-visible LOWER bound for the slot budget, via
++ * MONO_WASM_ALC_UNLOAD_REFERRER_SLOT_BUDGET. Clamped to
++ * ALC_REFERRER_SCAN_SLOT_BUDGET, so an override can only ever SHRINK the walk and never lift the
++ * ceiling this surface promises -- the same direction-of-travel rule the condemned-handle walk's
++ * budget follows.
++ *
++ * It exists because saturation was otherwise unreachable from a test: a test heap cannot produce
++ * two million reference slots, so deleting the charge entirely would have left every assertion
++ * passing. A bound nothing can cross is a bound asserted by comment. Read once, because an env
++ * lookup must not happen inside a GC pause.
++ */
++static gint32
++alc_referrer_scan_slot_budget (void)
++{
++	static gint32 budget = -1;
++	if (budget == -1) {
++		budget = ALC_REFERRER_SCAN_SLOT_BUDGET;
++		char *val = g_getenv ("MONO_WASM_ALC_UNLOAD_REFERRER_SLOT_BUDGET");
++		if (val) {
++			gint64 parsed = g_ascii_strtoll (val, NULL, 10);
++			/* Only a positive, strictly smaller value is honoured; anything else leaves the
++			 * production budget in place rather than silently accepting nonsense. */
++			if (parsed > 0 && parsed < ALC_REFERRER_SCAN_SLOT_BUDGET)
++				budget = (gint32)parsed;
++			g_free (val);
++		}
++	}
++	return budget;
++}
 +
 +/* Explicit, separate opt-in on top of MONO_WASM_ENABLE_ALC_UNLOAD (see DOUBLE OPT-IN above).
 + * Read once: an env lookup must not be repeated inside a GC pause. */
@@ -642,7 +779,7 @@ index 1054345..99895f5 100644
 +	memset (&scan, 0, sizeof (scan));
 +	scan.condemned_objects = objects;
 +	scan.object_budget = ALC_REFERRER_SCAN_OBJECT_BUDGET;
-+	scan.reference_slot_budget = ALC_REFERRER_SCAN_SLOT_BUDGET;
++	scan.reference_slot_budget = alc_referrer_scan_slot_budget ();
 +	sgen_scan_referrers_of_condemned (&scan);
 +
 +	/* One summary line, then one line per described referrer. The summary carries the figures
@@ -652,7 +789,7 @@ index 1054345..99895f5 100644
 +		"[alc-referrers] witnesses=%u referenced=%d edges=%d dependent=%d described=%d objects=%d/%d slots=%d/%d ephemerons=%d saturated=%d",
 +		g_hash_table_size (objects), scan.witnesses_referenced, scan.referrer_edges,
 +		scan.dependent_edges, scan.referrers_recorded, scan.objects_scanned, scan.objects_visited,
-+		scan.reference_slots_visited, ALC_REFERRER_SCAN_SLOT_BUDGET,
++		scan.reference_slots_visited, alc_referrer_scan_slot_budget (),
 +		scan.ephemeron_entries_visited, scan.saturated ? 1 : 0);
 +
 +	for (gint32 i = 0; i < scan.referrers_recorded; ++i) {
@@ -681,6 +818,8 @@ index 1054345..99895f5 100644
 +	 * `dependent` rows in `referrers`, which reported 0 whenever the row or witness caps were
 +	 * already spent -- so a dependent edge that WAS found could read as absent. */
 +	alc_referrer_last_dependent_edges = scan.dependent_edges;
++	alc_referrer_last_slots_visited = scan.reference_slots_visited;
++	alc_referrer_last_saturated = scan.saturated ? 1 : 0;
 +	alc_referrer_scans_reported++;
 +
 +	g_hash_table_destroy (objects);
@@ -694,7 +833,7 @@ index 1054345..99895f5 100644
  static void
  retired_scout_targets_add (MonoMemoryManager *memory_manager)
  {
-@@ -953,8 +1212,14 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
+@@ -953,8 +1253,14 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
  	if (!alc->unloading)
  		return FORCE_UNLOAD_REJECTED;
  
@@ -710,7 +849,7 @@ index 1054345..99895f5 100644
  
  	mono_alc_free (alc);
  	return FORCE_UNLOAD_COMPLETED;
-@@ -1032,7 +1297,24 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+@@ -1032,7 +1338,30 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
  	 * scout ran and refused" from "the scout never ran": a never-dying witness climbs this
  	 * counter while kind 7 stays flat.
  	 *
@@ -732,11 +871,17 @@ index 1054345..99895f5 100644
 +	 * These are LAST-SCAN values, not monotonic; read kind 11 around them to know which scan they
 +	 * describe. Independent gauges, not a tuple.
 +	 *
-+	 * Kinds 14-24 DO NOT EXIST: the condemned-set root classification is not a family of stat
++	 * Kinds 14 and 15 — reference slots looked up by the most recently reported referrer scan,
++	 * and whether that scan SATURATED. They exist so the slot budget is falsifiable: a test heap
++	 * cannot reach the production budget, so without a lowered budget (see
++	 * MONO_WASM_ALC_UNLOAD_REFERRER_SLOT_BUDGET) and these two gauges, deleting the per-slot
++	 * charge outright would leave every assertion passing. Last-scan values, like kinds 12 and 13.
++	 *
++	 * Kinds 16-24 DO NOT EXIST: the condemned-set root classification is not a family of stat
  	 * kinds at all. It is delivered as one whole tuple by InternalGetCondemnedSnapshot, for the
  	 * reasons in the "Root classification for condemned collectible contexts" block at the top
  	 * of this file, which is its only contract. Unknown kinds keep returning -1 here.
-@@ -1072,6 +1354,12 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+@@ -1072,6 +1401,16 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
  		return collectible_alc_native_structs;
  	case 10:
  		return scout_completion_deferral_count;
@@ -746,14 +891,18 @@ index 1054345..99895f5 100644
 +		return alc_referrer_last_edges;
 +	case 13:
 +		return alc_referrer_last_dependent_edges;
++	case 14:
++		return alc_referrer_last_slots_visited;
++	case 15:
++		return alc_referrer_last_saturated;
  	default:
  		return -1;
  	}
 diff --git a/src/mono/mono/metadata/gc-internals.h b/src/mono/mono/metadata/gc-internals.h
-index 1c51c11..747d1fc 100644
+index 1c51c11..ca0f255 100644
 --- a/src/mono/mono/metadata/gc-internals.h
 +++ b/src/mono/mono/metadata/gc-internals.h
-@@ -490,6 +490,149 @@ typedef struct {
+@@ -490,6 +490,154 @@ typedef struct {
  } MonoSgenCondemnedHandleScan;
  
  void sgen_scan_handles_into_managers (MonoSgenCondemnedHandleScan *scan);
@@ -879,6 +1028,11 @@ index 1c51c11..747d1fc 100644
 +	 * caps must not be able to make a found edge look absent, which is the whole reason this is
 +	 * separate from counting `dependent` rows in `referrers`. */
 +	gint32 dependent_edges;
++	/* OUT: of referrer_edges, how many were DEPENDENT edges (ephemeron key->value). Counted for
++	 * every such edge found, independent of whether a row was recorded for it -- the description
++	 * caps must not be able to make a found edge look absent, which is the whole reason this is
++	 * separate from counting `dependent` rows in `referrers`. */
++	gint32 dependent_edges;
 +	/* OUT: distinct condemned objects found to have at least one referrer. */
 +	gint32 witnesses_referenced;
 +	/* OUT: objects the heap iterators presented. This is the TRUE total, not an estimate: the
@@ -930,10 +1084,10 @@ index 4275a39..4a3191e 100644
  mono_mem_manager_new (MonoAssemblyLoadContext **alcs, int nalcs, gboolean collectible);
  
 diff --git a/src/mono/mono/metadata/sgen-mono.c b/src/mono/mono/metadata/sgen-mono.c
-index fd4e6e5..2a569d0 100644
+index fd4e6e5..d22e3ef 100644
 --- a/src/mono/mono/metadata/sgen-mono.c
 +++ b/src/mono/mono/metadata/sgen-mono.c
-@@ -2064,6 +2064,299 @@ sgen_scan_handles_into_managers (MonoSgenCondemnedHandleScan *scan)
+@@ -2064,6 +2064,312 @@ sgen_scan_handles_into_managers (MonoSgenCondemnedHandleScan *scan)
  
  	sgen_condemned_scan_in_progress = FALSE;
  }
@@ -1165,37 +1319,39 @@ index fd4e6e5..2a569d0 100644
 +	sgen_referrer_scan_witnesses_admitted = 0;
 +
 +	/*
-+	 * The same three regions mono_gc_walk_heap covers, in the same order, because between them
-+	 * they are the heap: the nursery, the major heap, and the large-object space. Missing one
-+	 * would silently narrow the search and make an empty result untrustworthy in a way
-+	 * `saturated` does not report.
-+	 */
-+	sgen_clear_nursery_fragments ();
-+	sgen_scan_area_with_callback (sgen_nursery_section->data, sgen_nursery_section->end_data,
-+			sgen_referrer_visit_object, scan, FALSE, TRUE);
-+	sgen_major_collector.iterate_objects (ITERATE_OBJECTS_SWEEP_ALL, sgen_referrer_visit_object, scan);
-+	sgen_los_iterate_objects (sgen_referrer_visit_object, scan);
-+
-+	/*
-+	 * SECOND PASS: dependent edges, which the three passes above CANNOT see.
++	 * FIRST PASS: dependent edges, which the heap walk below CANNOT see.
 +	 *
 +	 * sgen zeroes the GC bitmap for System.Runtime.Ephemeron (object.c, "An Ephemeron cannot be
 +	 * marked by sgen"), so an ephemeron array's descriptor reports no references and every
-+	 * descriptor-driven walk -- including this one -- misses the key->value edge entirely. The
-+	 * edge is nonetheless a real root: sgen_client_mark_ephemerons marks the value whenever the
-+	 * key is alive, which is exactly how a ConditionalWeakTable or DependentHandle keeps its
++	 * descriptor-driven walk -- including the one below -- misses the key->value edge entirely.
++	 * The edge is nonetheless a real root: sgen_client_mark_ephemerons marks the value whenever
++	 * the key is alive, which is exactly how a ConditionalWeakTable or DependentHandle keeps its
 +	 * value reachable. Without this pass a witness held only as a dependent value would produce
 +	 * an UNSATURATED EMPTY report, contradicting the one thing an empty report is supposed to
 +	 * mean.
 +	 *
-+	 * The liveness test and the tombstone skip mirror sgen_client_mark_ephemerons so that this
-+	 * pass reports the same edges the collector actually traverses -- a dead key's value is not
-+	 * a root, and reporting it would invent a holder. The referrer recorded is the KEY, since
-+	 * "alive as long as this key is" is the actionable identity; the array is not.
++	 * NO LIVENESS TEST, deliberately, and it would be WRONG to add one here.
++	 * sgen_client_clear_unreachable_ephemerons already ran inside the collection that is
++	 * finishing: it unlinked and freed every node whose array was dead, and tombstoned every
++	 * entry whose key was dead (clearing its value). So this list is ALREADY pruned to exactly
++	 * the live arrays and live-keyed entries, and skipping NULL/tombstone keys is the entire
++	 * test required. An earlier revision called sgen_is_object_alive_for_current_gen here to
++	 * mirror the collector, which silently dropped live PROMOTED entries: the major pass below
++	 * passes ITERATE_OBJECTS_SWEEP_ALL, marksweep's sweep_block clears block->mark_words, and
++	 * with sgen_current_collection_generation already -1 that predicate falls through to
++	 * sgen_major_is_object_alive and reads the cleared bit.
++	 *
++	 * RUNS FIRST, for two reasons. It shares the slot budget, and running it after the heap walk
++	 * meant a saturating walk could starve it completely -- silently reinstating the blind spot
++	 * this pass exists to close, in exactly the small-budget/large-heap case where it matters
++	 * most. It is also the cheapest pass and the one whose findings are most actionable.
++	 *
++	 * The referrer recorded is the KEY: "alive exactly as long as this key is" is the actionable
++	 * identity, and the ephemeron array that happens to hold the pair is not.
 +	 */
 +	for (EphemeronLinkNode *current = ephemeron_list; current; current = current->next) {
 +		MonoArray *array = current->array;
-+		if (!array || !sgen_is_object_alive_for_current_gen ((GCObject*)array))
++		if (!array)
 +			continue;
 +
 +		Ephemeron *cur = mono_array_addr_internal (array, Ephemeron, 0);
@@ -1206,15 +1362,13 @@ index fd4e6e5..2a569d0 100644
 +			GCObject *key = cur->key;
 +			if (!key || key == tombstone)
 +				continue;
-+			if (!sgen_is_object_alive_for_current_gen (key))
-+				continue;
 +
 +			GCObject *value = cur->value;
 +			if (!value)
 +				continue;
 +
-+			/* Charged like any other reference slot, so one enormous CWT cannot cost more than
-+			 * the budget allows. */
++			/* Charged like any other reference slot, so one enormous CWT cannot outspend the
++			 * budget. */
 +			if (!sgen_referrer_charge_slot ())
 +				break;
 +
@@ -1223,6 +1377,19 @@ index fd4e6e5..2a569d0 100644
 +				sgen_referrer_record (key, value, (guint32)(cur - mono_array_addr_internal (array, Ephemeron, 0)), TRUE);
 +		}
 +	}
++
++	/*
++	 * SECOND PASS: the same three regions mono_gc_walk_heap covers, in the same order, because
++	 * between them they are the heap: the nursery, the major heap, and the large-object space.
++	 * Missing one would silently narrow the search and make an empty result untrustworthy in a
++	 * way `saturated` does not report.
++	 */
++	sgen_clear_nursery_fragments ();
++	sgen_scan_area_with_callback (sgen_nursery_section->data, sgen_nursery_section->end_data,
++			sgen_referrer_visit_object, scan, FALSE, TRUE);
++	sgen_major_collector.iterate_objects (ITERATE_OBJECTS_SWEEP_ALL, sgen_referrer_visit_object, scan);
++	sgen_los_iterate_objects (sgen_referrer_visit_object, scan);
++
 +
 +	g_hash_table_destroy (sgen_referrer_scan_described);
 +	sgen_referrer_scan_described = NULL;

--- a/patches/0015-report-referrers-of-condemned-collectible-alc-witnesses.patch
+++ b/patches/0015-report-referrers-of-condemned-collectible-alc-witnesses.patch
@@ -194,12 +194,12 @@ root is found and fixed, or when the stop-rule fires.
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
 ---
  .../tests/ForcedNativeUnloadTests.cs          | 296 +++++++++++++++
- .../mono/metadata/assembly-load-context.c     | 343 +++++++++++++++++-
- src/mono/mono/metadata/gc-internals.h         | 143 ++++++++
+ .../mono/metadata/assembly-load-context.c     | 350 +++++++++++++++++-
+ src/mono/mono/metadata/gc-internals.h         | 143 +++++++
  src/mono/mono/metadata/loader-internals.h     |  15 +
- src/mono/mono/metadata/sgen-mono.c            | 306 ++++++++++++++++
+ src/mono/mono/metadata/sgen-mono.c            | 306 +++++++++++++++
  src/mono/mono/metadata/sgen-stw.c             |  16 +
- 6 files changed, 1117 insertions(+), 2 deletions(-)
+ 6 files changed, 1124 insertions(+), 2 deletions(-)
 
 diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 index 2b2f170..0bb1a45 100644
@@ -523,10 +523,10 @@ index 2b2f170..0bb1a45 100644
          public async Task ForceNativeUnload_AfterCompleted_ManagedLoadApisReject()
          {
 diff --git a/src/mono/mono/metadata/assembly-load-context.c b/src/mono/mono/metadata/assembly-load-context.c
-index 1054345..bda279b 100644
+index 1054345..9b86cff 100644
 --- a/src/mono/mono/metadata/assembly-load-context.c
 +++ b/src/mono/mono/metadata/assembly-load-context.c
-@@ -515,6 +515,306 @@ alc_condemned_snapshot_fill (gint32 *fields, gint32 length, gint32 slot_budget)
+@@ -515,6 +515,313 @@ alc_condemned_snapshot_fill (gint32 *fields, gint32 length, gint32 slot_budget)
  	return ALC_SNAPSHOT_FIELD_COUNT;
  }
  
@@ -669,10 +669,17 @@ index 1054345..bda279b 100644
 +		budget = ALC_REFERRER_SCAN_SLOT_BUDGET;
 +		char *val = g_getenv ("MONO_WASM_ALC_UNLOAD_REFERRER_SLOT_BUDGET");
 +		if (val) {
-+			gint64 parsed = g_ascii_strtoll (val, NULL, 10);
-+			/* Only a positive, strictly smaller value is honoured; anything else leaves the
-+			 * production budget in place rather than silently accepting nonsense. */
-+			if (parsed > 0 && parsed < ALC_REFERRER_SCAN_SLOT_BUDGET)
++			/* strtol, not g_ascii_strtoll: eglib does not provide the latter, and an earlier
++			 * revision calling it failed the build with an implicit-declaration error. This is
++			 * the same idiom mono/utils/options.c uses, and <stdlib.h> arrives via eglib's
++			 * glib.h. */
++			char *end = NULL;
++			long parsed = strtol (val, &end, 10);
++			/* Only a positive, strictly smaller, fully-parsed value is honoured; anything else --
++			 * trailing garbage, zero, negative, or a value at or above the production budget --
++			 * leaves the production budget in place rather than silently accepting nonsense. An
++			 * overflowing value saturates to LONG_MAX and so fails the upper bound too. */
++			if (end && end != val && *end == '\0' && parsed > 0 && parsed < ALC_REFERRER_SCAN_SLOT_BUDGET)
 +				budget = (gint32)parsed;
 +			g_free (val);
 +		}
@@ -833,7 +840,7 @@ index 1054345..bda279b 100644
  static void
  retired_scout_targets_add (MonoMemoryManager *memory_manager)
  {
-@@ -953,8 +1253,14 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
+@@ -953,8 +1260,14 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
  	if (!alc->unloading)
  		return FORCE_UNLOAD_REJECTED;
  
@@ -849,7 +856,7 @@ index 1054345..bda279b 100644
  
  	mono_alc_free (alc);
  	return FORCE_UNLOAD_COMPLETED;
-@@ -1032,7 +1338,30 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+@@ -1032,7 +1345,30 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
  	 * scout ran and refused" from "the scout never ran": a never-dying witness climbs this
  	 * counter while kind 7 stays flat.
  	 *
@@ -881,7 +888,7 @@ index 1054345..bda279b 100644
  	 * kinds at all. It is delivered as one whole tuple by InternalGetCondemnedSnapshot, for the
  	 * reasons in the "Root classification for condemned collectible contexts" block at the top
  	 * of this file, which is its only contract. Unknown kinds keep returning -1 here.
-@@ -1072,6 +1401,16 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+@@ -1072,6 +1408,16 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
  		return collectible_alc_native_structs;
  	case 10:
  		return scout_completion_deferral_count;

--- a/patches/0015-report-referrers-of-condemned-collectible-alc-witnesses.patch
+++ b/patches/0015-report-referrers-of-condemned-collectible-alc-witnesses.patch
@@ -46,7 +46,7 @@ DOUBLE OPT-IN. MONO_WASM_ENABLE_ALC_UNLOAD does not arm this on its own; it
 also needs MONO_WASM_ALC_UNLOAD_REFERRER_SCAN. Unlike the snapshot -- a
 read-only gauge a caller chooses to poll -- this adds work to a collection
 pause, so a flagged session that has not asked for referrers pays one load
-and a branch.
+and a branch. The regression asserts that gating in both directions.
 
 WHAT IT BOUNDS, AND WHAT IT DOES NOT. object_budget caps the per-object
 reference scan and NOT the object enumeration: sgen's iterators run to
@@ -65,47 +65,158 @@ the assembly trace, so it is invisible without --trace=asm at info or finer.
 An empty console is therefore never evidence of anything, which the contract
 block says in those words.
 
-Two things worth flagging for review, both found while writing this:
+THE PRECONDITION IS NOT ASSERTED, and that is deliberate rather than an
+omission. Two successive drafts asserted it wrongly, both of which would have
+aborted the runtime on the first armed scan, so the candidates are now
+recorded at the site so neither returns:
 
-  * The precondition is asserted as sgen_is_world_stopped (), NOT as "a
-    collection is in progress". sgen clears
-    sgen_current_collection_generation at the end of the minor/major
-    collection function, which runs BEFORE sgen_restart_world, so at the
-    pre-start-world point the generation already reads -1 just as it does
-    outside a collection. An earlier draft asserted != -1 and would have
-    aborted the runtime on the first armed collection.
-  * Taking alcs_lock inside a GC pause would be a real hazard on a
-    threads-enabled runtime, where mono_coop_mutex_lock does a
-    MONO_ENTER_GC_SAFE transition when contended. It is sound here only
-    because this surface is DISABLE_THREADS-only and every MonoCoopMutex
-    operation is an empty inline there. The reasoning is recorded at the
-    call site rather than left implicit.
+  * sgen_current_collection_generation != -1 is false here. sgen clears the
+    generation at the end of the minor/major collection function, which runs
+    before sgen_restart_world.
+  * sgen_is_world_stopped () is also false here. sgen_restart_world clears
+    world_is_stopped BEFORE calling sgen_client_restart_world, so the flag is
+    already down when the hook runs. The mutators have NOT resumed --
+    unified_suspend_restart_world comes later in that same function -- but the
+    bookkeeping flag does not say so.
+
+mono_gc_walk_heap has the identical contract and asserts nothing about the
+world either; it states the requirement and relies on its callers. This
+follows that precedent, and the single guarded call site is what establishes
+the invariant. A flag set by that caller purely to be asserted would certify
+nothing, so there is none.
+
+Also worth flagging: taking alcs_lock inside a GC pause would be a real
+hazard on a threads-enabled runtime, where mono_coop_mutex_lock does a
+MONO_ENTER_GC_SAFE transition when contended. It is sound here only because
+this surface is DISABLE_THREADS-only and every MonoCoopMutex operation is an
+empty inline there. The reasoning is recorded at the call site rather than
+left implicit, because it stops being true the moment someone builds this
+with threads enabled.
+
+OBSERVABILITY, so this can actually be tested. The scan's only other output
+is trace text, so nothing could distinguish an armed scan from one that never
+ran -- which is precisely how two wrong assertions survived a fully green
+build. Stat kind 11 now counts scans that completed a heap walk AND emitted
+their report, deliberately excluding the early return taken when the
+condemned set has already emptied, so a bump cannot be earned by a scan that
+never looked at the heap. It is a lone monotonic gauge like kinds 7 and 10,
+not a field of a tuple, so it reintroduces none of the cross-read
+consistency problems that shaped the snapshot surface.
+
+ForcedUnload_ReferrerScan_RefusalIsServedAtNextCollection drives a refusal
+with the same rooted pointer-free probe the existing witness regression uses,
+forces a collection, and asserts kind 11 advanced when the second opt-in is
+set and did NOT advance when it is absent. It asserts the refusal itself
+rather than tolerating a Completed, since a Completed would make the rest
+vacuous.
 
 Temporary diagnostic scaffolding on the same terms and the same tracking
 issue (#176) as the snapshot it complements: it retires when the residual
 root is found and fixed, or when the stop-rule fires.
 
-NOT COMPILE-VERIFIED LOCALLY. This was authored against the pinned commit
-with the series applied, but building the WASM runtime is not something the
-author can do on this machine; the runtime CI on this PR is the first real
-compile. Reviewers should treat a green CI as the first evidence it builds,
-and the behaviour claims above as unexercised until someone runs a flagged
-session with the scan armed.
-
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
 ---
- .../mono/metadata/assembly-load-context.c     | 209 +++++++++++++++++-
- src/mono/mono/metadata/gc-internals.h         |  91 ++++++++
+ .../tests/ForcedNativeUnloadTests.cs          |  70 ++++++
+ .../mono/metadata/assembly-load-context.c     | 233 +++++++++++++++++-
+ src/mono/mono/metadata/gc-internals.h         |  91 +++++++
  src/mono/mono/metadata/loader-internals.h     |  15 ++
- src/mono/mono/metadata/sgen-mono.c            | 176 +++++++++++++++
+ src/mono/mono/metadata/sgen-mono.c            | 187 ++++++++++++++
  src/mono/mono/metadata/sgen-stw.c             |  16 ++
- 5 files changed, 506 insertions(+), 1 deletion(-)
+ 6 files changed, 610 insertions(+), 2 deletions(-)
 
+diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
+index 2b2f170..b9e708f 100644
+--- a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
++++ b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
+@@ -178,6 +178,14 @@ private static bool FlagEnabled
+         private static bool GcHookRequested =>
+             Environment.GetEnvironmentVariable("MONO_WASM_ALC_UNLOAD_TEST_GC_HOOK") == "1";
+ 
++        // Set by the CI single-threaded wasm leg: arms the pause-time condemned-REFERRER scan (the
++        // "Referrer lookup for condemned collectible contexts" block in assembly-load-context.c).
++        // It is a SECOND opt-in on top of MONO_WASM_ENABLE_ALC_UNLOAD, because that scan adds work
++        // to a collection pause rather than being a gauge a caller polls -- so the flag alone must
++        // not arm it, which the regression below asserts in both directions.
++        private static bool ReferrerScanRequested =>
++            Environment.GetEnvironmentVariable("MONO_WASM_ALC_UNLOAD_REFERRER_SCAN") == "1";
++
+         // Returns true (and the caller should no-op) only on a genuinely unpatched runtime. When CI
+         // asserts the bridge must exist, a missing member fails loudly instead of self-skipping and
+         // masking the regression.
+@@ -1585,6 +1593,68 @@ public async Task ForcedUnload_RootedPointerFreeObjects_BlockNativeFree()
+             await RunConservativelyPinnedLosWitnessProtocol();
+         }
+ 
++        /// <summary>
++        /// A quiescence refusal must arm the condemned-referrer scan, and the next collection must
++        /// SERVE it -- and with the second opt-in absent, must not.
++        ///
++        /// This exists because the referrer scan's only other output is runtime trace text, which
++        /// no test can read: before this, CI never armed that code at all, so a wrong assertion
++        /// inside it survived a fully green build twice. Stat kind 11 counts scans that completed a
++        /// heap walk AND emitted their report, so a bump proves the whole serving path ran rather
++        /// than merely that a request was recorded.
++        ///
++        /// The refusal is produced with the same rooted pointer-free probe as
++        /// ForcedUnload_RootedPointerFreeObjects_BlockNativeFree: post-fix that probe roots the
++        /// witness deterministically, which is exactly the state whose holder this diagnostic
++        /// exists to identify.
++        /// </summary>
++        [Fact]
++        [MethodImpl(MethodImplOptions.NoInlining)]
++        public void ForcedUnload_ReferrerScan_RefusalIsServedAtNextCollection()
++        {
++            if (BridgeMissing())
++            {
++                return;
++            }
++
++            int before = ScoutStats(11);
++
++            if (!ProtocolActive)
++            {
++                // No teardown protocol here: on a threads-enabled runtime the whole stat surface
++                // reports unavailable (-1), and with the flag off nothing is collectible to
++                // condemn. Either way the gauge must not move.
++                GcQuiesce();
++                Assert.Equal(before, ScoutStats(11));
++                return;
++            }
++
++            var context = new ResourceAssemblyLoadContext(true) { LoadBy = LoadBy.Stream };
++            object[] rooted = LoadUnloadReturningRootedPointerFreeProbe(context, losArray: true, new WeakReference[1]);
++
++            // The refusal is the trigger. If this ever reports Completed the probe stopped rooting
++            // the witness, which is a regression in its own right and would silently make the
++            // assertions below vacuous -- so it is asserted rather than tolerated.
++            Assert.Equal(NotQuiescent, Force(context));
++
++            GcQuiesce();
++
++            int after = ScoutStats(11);
++            if (ReferrerScanRequested)
++            {
++                Assert.True(after > before,
++                    $"MONO_WASM_ALC_UNLOAD_REFERRER_SCAN is set and a refusal was recorded, but no scan reported: kind 11 was {before} and is {after}. Either the pause hook never ran, or it aborted/returned before emitting its report.");
++            }
++            else
++            {
++                Assert.Equal(before, after);
++            }
++
++            // The probe must outlive every assertion above: dropping it earlier would let the
++            // witness die, clear the condemned set, and turn the refusal into a Completed.
++            GC.KeepAlive(rooted);
++        }
++
+         [Fact]
+         public async Task ForceNativeUnload_AfterCompleted_ManagedLoadApisReject()
+         {
 diff --git a/src/mono/mono/metadata/assembly-load-context.c b/src/mono/mono/metadata/assembly-load-context.c
-index 1054345..a2abd44 100644
+index 1054345..a6cace8 100644
 --- a/src/mono/mono/metadata/assembly-load-context.c
 +++ b/src/mono/mono/metadata/assembly-load-context.c
-@@ -515,6 +515,207 @@ alc_condemned_snapshot_fill (gint32 *fields, gint32 length, gint32 slot_budget)
+@@ -515,6 +515,220 @@ alc_condemned_snapshot_fill (gint32 *fields, gint32 length, gint32 slot_budget)
  	return ALC_SNAPSHOT_FIELD_COUNT;
  }
  
@@ -175,6 +286,15 @@ index 1054345..a2abd44 100644
 +/* Set by a refusal, consumed by the next collection pause. Coalescing, not a queue (see the
 + * block above). */
 +static gboolean alc_referrer_scan_requested;
++
++/* Monotonic count of scans that completed a heap walk AND emitted their report. Exposed as stat
++ * kind 11 so a regression can prove the serving path ran at all: without it the only evidence
++ * this code ever executes is trace output, which no test can read. Deliberately counts the
++ * REPORTED case only -- a request served when the condemned set had already emptied took the
++ * early return below and walked nothing, so counting it would let a test pass on a scan that
++ * never looked at the heap. A single independent gauge, not one field of a tuple: nothing here
++ * has to be read consistently with anything else. */
++static gint32 alc_referrer_scans_reported;
 +
 +/* Objects whose reference fields the pause-time walk may examine. Sized so the walk costs a
 + * bounded slice of a pause on the heaps this diagnostic runs against, in the same spirit as
@@ -302,6 +422,10 @@ index 1054345..a2abd44 100644
 +			row->referrer, row->field_offset);
 +	}
 +
++	/* AFTER the report: the counter's promise is that the summary and any rows were emitted, so
++	 * a test observing it knows the walk happened rather than merely that a request existed. */
++	alc_referrer_scans_reported++;
++
 +	g_hash_table_destroy (objects);
 +#else
 +	/* No sgen: no heap walk exists. Say so, rather than letting silence read as "no referrers". */
@@ -313,7 +437,7 @@ index 1054345..a2abd44 100644
  static void
  retired_scout_targets_add (MonoMemoryManager *memory_manager)
  {
-@@ -953,8 +1154,14 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
+@@ -953,8 +1167,14 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalForceNativeUnload (g
  	if (!alc->unloading)
  		return FORCE_UNLOAD_REJECTED;
  
@@ -329,6 +453,31 @@ index 1054345..a2abd44 100644
  
  	mono_alc_free (alc);
  	return FORCE_UNLOAD_COMPLETED;
+@@ -1032,7 +1252,14 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+ 	 * scout ran and refused" from "the scout never ran": a never-dying witness climbs this
+ 	 * counter while kind 7 stays flat.
+ 	 *
+-	 * Kinds 11-24 DO NOT EXIST: the condemned-set root classification is not a family of stat
++	 * Kind 11 — monotonic count of condemned-REFERRER scans that completed a heap walk and
++	 * emitted their report (see the "Referrer lookup for condemned collectible contexts" block).
++	 * It exists because that surface's only other output is trace text, so without it no test
++	 * can tell an armed scan from a scan that never ran. It is a lone gauge like kinds 7 and 10,
++	 * NOT a field of a tuple, so it carries none of the cross-read consistency requirements that
++	 * shaped the snapshot below.
++	 *
++	 * Kinds 12-24 DO NOT EXIST: the condemned-set root classification is not a family of stat
+ 	 * kinds at all. It is delivered as one whole tuple by InternalGetCondemnedSnapshot, for the
+ 	 * reasons in the "Root classification for condemned collectible contexts" block at the top
+ 	 * of this file, which is its only contract. Unknown kinds keep returning -1 here.
+@@ -1072,6 +1299,8 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalGetScoutRetirementSt
+ 		return collectible_alc_native_structs;
+ 	case 10:
+ 		return scout_completion_deferral_count;
++	case 11:
++		return alc_referrer_scans_reported;
+ 	default:
+ 		return -1;
+ 	}
 diff --git a/src/mono/mono/metadata/gc-internals.h b/src/mono/mono/metadata/gc-internals.h
 index 1c51c11..b9f99a2 100644
 --- a/src/mono/mono/metadata/gc-internals.h
@@ -458,10 +607,10 @@ index 4275a39..4a3191e 100644
  mono_mem_manager_new (MonoAssemblyLoadContext **alcs, int nalcs, gboolean collectible);
  
 diff --git a/src/mono/mono/metadata/sgen-mono.c b/src/mono/mono/metadata/sgen-mono.c
-index fd4e6e5..cb69a5d 100644
+index fd4e6e5..a331fc7 100644
 --- a/src/mono/mono/metadata/sgen-mono.c
 +++ b/src/mono/mono/metadata/sgen-mono.c
-@@ -2064,6 +2064,182 @@ sgen_scan_handles_into_managers (MonoSgenCondemnedHandleScan *scan)
+@@ -2064,6 +2064,193 @@ sgen_scan_handles_into_managers (MonoSgenCondemnedHandleScan *scan)
  
  	sgen_condemned_scan_in_progress = FALSE;
  }
@@ -606,13 +755,24 @@ index fd4e6e5..cb69a5d 100644
 +		return;
 +
 +	/*
-+	 * See PRECONDITION above. The check is sgen_is_world_stopped () and deliberately NOT
-+	 * "a collection is in progress": sgen clears sgen_current_collection_generation at the end
-+	 * of the minor/major collection function, which runs BEFORE sgen_restart_world, so at the
-+	 * pre-start-world point the generation already reads -1 just as it does outside a
-+	 * collection. World-stopped is the property this walk actually depends on.
++	 * See PRECONDITION above. It is NOT asserted, and that is deliberate: at this hook there is
++	 * no predicate that expresses it. Both obvious candidates are already false here, which is
++	 * recorded so neither gets re-added:
++	 *
++	 *   - sgen_current_collection_generation != -1. sgen clears the generation at the end of the
++	 *     minor/major collection function, which runs before sgen_restart_world, so it reads -1
++	 *     here exactly as it does outside a collection.
++	 *   - sgen_is_world_stopped (). sgen_restart_world clears world_is_stopped BEFORE calling
++	 *     sgen_client_restart_world, so the flag is already FALSE by the time this runs. The
++	 *     mutators have not resumed yet -- unified_suspend_restart_world comes later in that
++	 *     same function -- but the bookkeeping flag does not say so, and asserting on it aborts
++	 *     the runtime on the first armed scan.
++	 *
++	 * mono_gc_walk_heap has the identical contract and asserts nothing about the world either;
++	 * it states the requirement and relies on its callers. This follows that, and the one call
++	 * site (sgen_client_restart_world, guarded) is what actually establishes the invariant. A
++	 * self-certifying flag set by that caller would assert nothing of value, so there is none.
 +	 */
-+	g_assert (sgen_is_world_stopped ());
 +	g_assert (!sgen_referrer_scan_in_progress);
 +
 +	/* No unbounded mode, for the same reason the handle scan has none: a diagnostic that runs

--- a/patches/0015-report-referrers-of-condemned-collectible-alc-witnesses.patch
+++ b/patches/0015-report-referrers-of-condemned-collectible-alc-witnesses.patch
@@ -195,11 +195,11 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
 ---
  .../tests/ForcedNativeUnloadTests.cs          | 296 +++++++++++++++
  .../mono/metadata/assembly-load-context.c     | 343 +++++++++++++++++-
- src/mono/mono/metadata/gc-internals.h         | 148 ++++++++
+ src/mono/mono/metadata/gc-internals.h         | 143 ++++++++
  src/mono/mono/metadata/loader-internals.h     |  15 +
  src/mono/mono/metadata/sgen-mono.c            | 306 ++++++++++++++++
  src/mono/mono/metadata/sgen-stw.c             |  16 +
- 6 files changed, 1122 insertions(+), 2 deletions(-)
+ 6 files changed, 1117 insertions(+), 2 deletions(-)
 
 diff --git a/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs b/src/libraries/System.Runtime.Loader/tests/ForcedNativeUnloadTests.cs
 index 2b2f170..0bb1a45 100644
@@ -899,10 +899,10 @@ index 1054345..bda279b 100644
  		return -1;
  	}
 diff --git a/src/mono/mono/metadata/gc-internals.h b/src/mono/mono/metadata/gc-internals.h
-index 1c51c11..ca0f255 100644
+index 1c51c11..747d1fc 100644
 --- a/src/mono/mono/metadata/gc-internals.h
 +++ b/src/mono/mono/metadata/gc-internals.h
-@@ -490,6 +490,154 @@ typedef struct {
+@@ -490,6 +490,149 @@ typedef struct {
  } MonoSgenCondemnedHandleScan;
  
  void sgen_scan_handles_into_managers (MonoSgenCondemnedHandleScan *scan);
@@ -1023,11 +1023,6 @@ index 1c51c11..ca0f255 100644
 +	 * referrer_edges is a DESCRIPTION cap, not truncation of the search -- distinct from
 +	 * `saturated`, which reports the search itself being cut short. */
 +	gint32 referrer_edges;
-+	/* OUT: of referrer_edges, how many were DEPENDENT edges (ephemeron key->value). Counted for
-+	 * every such edge found, independent of whether a row was recorded for it -- the description
-+	 * caps must not be able to make a found edge look absent, which is the whole reason this is
-+	 * separate from counting `dependent` rows in `referrers`. */
-+	gint32 dependent_edges;
 +	/* OUT: of referrer_edges, how many were DEPENDENT edges (ephemeron key->value). Counted for
 +	 * every such edge found, independent of whether a row was recorded for it -- the description
 +	 * caps must not be able to make a found edge look absent, which is the whole reason this is

--- a/scripts/check-loader-results.sh
+++ b/scripts/check-loader-results.sh
@@ -8,21 +8,32 @@
 #   1. requires a real number of EXECUTED tests (passed + failed, i.e. excluding skipped);
 #   2. requires each named ALC lifecycle test to be PRESENT and PASSED (not skipped / not missing).
 #
-# Usage: check-loader-results.sh <testResults.xml> <label> [mode]
+# Usage: check-loader-results.sh <testResults.xml> <label> [mode] [scan]
 #   mode "st" (default): single-threaded browser leg. Requires the always-run lifecycle tests and
 #     intentionally does NOT require the threads-enabled rejection test (it is
 #     [ConditionalFact(IsThreadingSupported)] and self-skips there).
 #   mode "mt": multithread (WasmEnableThreads=true) leg. Additionally REQUIRES
 #     ForceNativeUnload_OnThreadsEnabledRuntime_IsRejected to be present AND passed (not skipped) —
 #     this is the only leg where that test executes, proving the runtime rejects the feature.
+#   scan "referrer": additionally REQUIRES the condemned-referrer scan tests to be present and
+#     passed. Passed on the ST legs where the collectible feature is ON — BOTH with the scan
+#     opt-in and without it, because the unarmed run asserts that the second opt-in actually
+#     gates, so those tests execute either way. Without this dimension the sentinel returned OK
+#     with all three names absent, i.e. deleting them was a silent no-op.
 set -euo pipefail
 
 results="${1:?usage: check-loader-results.sh <testResults.xml> <label> [st|mt]}"
 label="${2:-run}"
 mode="${3:-st}"
+scan="${4:-none}"
 
 if [ "$mode" != "st" ] && [ "$mode" != "mt" ]; then
   echo "[$label] unknown mode '$mode' (expected 'st' or 'mt')"
+  exit 1
+fi
+
+if [ "$scan" != "none" ] && [ "$scan" != "referrer" ]; then
+  echo "[$label] unknown scan '$scan' (expected 'referrer' or omitted)"
   exit 1
 fi
 
@@ -92,6 +103,17 @@ ForceNativeUnload_OnThreadsEnabledRuntime_IsRejected
 else
   : # ST legs: ForceNativeUnload_OnThreadsEnabledRuntime_IsRejected intentionally NOT required —
     # it self-skips there; the dedicated multithread leg (mode=mt) requires it instead.
+fi
+
+if [ "$scan" = "referrer" ]; then
+  # These execute on every ST leg with the collectible feature ON, armed or not: the unarmed run
+  # asserts the scan opt-in gates. Requiring them here is what stops their deletion — or a
+  # regression to self-skipping — from reading as green.
+  required_tests="$required_tests
+ForcedUnload_ReferrerScan_RefusalIsServedAtNextCollection
+ForcedUnload_ReferrerScan_ReportsConditionalWeakTableDependentEdge
+ForcedUnload_ReferrerScan_LargeReferenceArrayStillReports
+"
 fi
 
 fail=0


### PR DESCRIPTION
Implements the diagnostic requested in #179. **Authored on spec rather than waiting for a design steer** — a concrete patch is easier to react to than a design question, and if the approach is wrong the code makes the objection specific. Happy to throw it away.

## Why this, and not more of #175

#175's handle classification answered its question in the negative. Across a downstream WASM host's stranding repro — repeated collectible-ALC load/unload cycles, forced-unload opt-in active — eight complete **unsaturated** sweeps report every handle bucket at 0 while the witness count never decays:

```
cycle=1  managers=2  liveWitnesses=2  strong=0 pinned=0 weakTrack=0  slotsVisited=86032/86032   saturated=0
cycle=8  managers=16 liveWitnesses=16 strong=0 pinned=0 weakTrack=0  slotsVisited=168946/168946 saturated=0
```

That rules out a GC handle *directly* targeting a condemned object — all #175 can ever see, because its attribution is one hop. The witnesses are still reachable, so the reference runs through the object graph, and no amount of further handle classification follows a graph. This is the reverse question: **for each condemned witness, which objects reference it.**

## What it does

One bounded pass over the heap with the world already stopped, reporting for each witness the **class of each referrer** and the field offset of the reference.

- **`sgen_scan_referrers_of_condemned`** (`sgen-mono.c`) mirrors the three regions `mono_gc_walk_heap` covers — nursery, major heap, LOS — with a scanner that tests each reference in place against the condemned set.
- **`assembly-load-context.c`** owns the trigger, the condemned set and the report, in a new contract block that is the single source for this surface exactly as #175's block is for the snapshot.
- **`sgen-stw.c`** calls the consumer at the pre-start-world point, under `DISABLE_THREADS` only.

**Why not just call `mono_gc_walk_heap`.** It buffers every reference of every object through a `MonoGCReferences` callback, with no budget and no way for the callback to stop — the same shape problem `sgen_gchandle_foreach_slot_bounded` was added to solve for the handle tables. This walk needs one hash lookup per reference and nothing else.

**Trigger.** A quiescence refusal is the only evidence a witness is still held, but it runs from an icall with the world *running*, and a heap walk needs the world stopped. So a refusal **records a request** and the next collection serves it. Consequences, stated plainly: the report is not attributable to one specific refusal, and if the process never collects again after a refusal, no report is ever produced. Requests coalesce rather than queue, so a host that retries in a loop gets one report, not one per retry.

**Double opt-in.** `MONO_WASM_ENABLE_ALC_UNLOAD` does not arm this; it also needs `MONO_WASM_ALC_UNLOAD_REFERRER_SCAN`. Unlike the snapshot — a read-only gauge a caller chooses to poll — this adds work to a collection pause, so a flagged session that has not asked for referrers pays one load and a branch.

## Limits, because they decide how a result should be read

- **`object_budget` bounds the reference scanning, not the enumeration.** sgen's iterators run to completion and their callbacks cannot stop them, and the walk passes `ITERATE_OBJECTS_SWEEP_ALL` exactly as `mono_gc_walk_heap` does — which forces a lazily-swept major heap to finish sweeping, and that is not free. A scan costs a full enumeration plus at most `object_budget` reference scans. The budget is a bound on the second half only and the contract says so in those words.
- **`objects_visited` is a true total, not an estimate** — a side benefit of the iterators always finishing — so `objects_scanned/objects_visited` plus `saturated` say exactly how much of the heap an answer covers. That is a better denominator than #175 could offer.
- **A referrer row is direct evidence. An empty report is much weaker** and means anything only when the scan did not saturate.
- **Silence is ambiguous and is not evidence.** The report goes to the assembly trace, so it is invisible without `--trace=asm` at info or finer (`monoTraceMask=asm`, `monoTraceLevel=info` in a browser host). Without the mask the scan still runs and says nothing, which looks exactly like "no referrers found".

## Two things found while writing this, both worth a reviewer's eye

1. **The precondition is `sgen_is_world_stopped ()`, deliberately not "a collection is in progress".** sgen clears `sgen_current_collection_generation` at the end of the minor/major collection function, which runs *before* `sgen_restart_world` — so at the pre-start-world point the generation already reads `-1`, just as it does outside a collection. An earlier draft asserted `!= -1` and **would have aborted the runtime on the first armed collection.** Worth knowing that the generation cannot distinguish these two points, since #175's sibling scan asserts on it.
2. **Taking `alcs_lock` inside a GC pause would be a real hazard on a threads-enabled runtime**, where `mono_coop_mutex_lock` does a `MONO_ENTER_GC_SAFE` transition when contended. It is sound here *only* because this surface is `DISABLE_THREADS`-only, where every `MonoCoopMutex` operation is an empty inline. The reasoning is recorded at the call site rather than left implicit, because it stops being true the moment someone builds this with threads on.

## Verification — and what is NOT verified

Done:

- **Fresh apply-check, byte-identical.** All 15 patches applied with `git apply --whitespace=fix` onto a clean checkout at the pinned commit `742e2f0` produce tree `eb92ed7cd4c24a5c1b67fd9123c5408e10b1fa40`, equal to the authored tree, re-verified after the review fixes in `ba922a3` (it was `3c4fcd6d` before them). `git diff --check` clean. The patch parses as a mailbox patch (`git mailinfo`).
- Incidentally confirms #177's claim that its metadata-only change leaves every applied tree unchanged: this baseline was authored against the pre-#177 patches and the post-#177 series reproduces the same tree.
- Series conventions matched: zeroed commit SHA, `Nick Randolph <noreply@platform.uno>` authorship (not the tooling identity #177 removed), LF endings, no product names per the cross-repo rule.

**Not done, and the gap still matters:**

- ~~This has never been compiled.~~ **It compiles.** CI on this PR is green: 11 build jobs pass, and the one that counts is `build_linux_job (Release, singlethread)` — the `DISABLE_THREADS` leg, i.e. the only configuration where this code is compiled rather than preprocessed away. The AOT and multithread legs passing prove only that the compiled-out path is intact. `test_loader_wasm` and `test_loader_wasm_mt` also pass.
- **A green loader sentinel does not exercise this diagnostic.** It proves the existing ALC regressions still pass, which is worth having, but nothing in CI turns the scan on — so the output format, the trigger timing and the 400000-object budget remain unvalidated in practice.
- **The behaviour is still unexercised.** No flagged session has run with `MONO_WASM_ALC_UNLOAD_REFERRER_SCAN` set.
- **No test**, for the reasons above: the surface is a pause-time side effect behind a double opt-in with trace-only output, and asserting on it from `System.Runtime.Loader.Tests` would need a managed observation channel bigger than the diagnostic itself. Say the word and I will add it.
- **Two review findings have already landed** (`ba922a3`), one of them a real logic bug that CI could not have caught — see the resolved threads. Worth noting that the second, a macro collapsed onto one physical line, is a case where **CI passing actively concealed a defect**: the preprocessor accepts it.

## Scope

Temporary diagnostic scaffolding on the same terms and the same tracking issue (#176) as the snapshot it complements: it retires when the residual root is found and fixed, or when the stop-rule fires. Not a supported runtime surface.
